### PR TITLE
Do not reconcile if mimir is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Do nothing if mimir is disabled to avoid deleting prometheus-meta-operator managed resources.
+
 ## [0.0.3] - 2024-05-24
 
 ### Changed

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -80,8 +80,13 @@ func (r *ClusterMonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Re
 		return ctrl.Result{}, errors.WithStack(err)
 	}
 
+	if !r.MonitoringEnabled {
+		logger.Info("Monitoring is disabled at the installation level")
+		return ctrl.Result{}, nil
+	}
+
 	// Handle deletion reconciliation loop.
-	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() || !r.MonitoringEnabled {
+	if !cluster.ObjectMeta.DeletionTimestamp.IsZero() {
 		logger.Info("Handling deletion for Cluster", "cluster", cluster.Name)
 		return r.reconcileDelete(ctx, cluster)
 	}
@@ -158,6 +163,5 @@ func (r *ClusterMonitoringReconciler) reconcileDelete(ctx context.Context, clust
 		}
 		logger.Info("removed finalizer", "finalizer", monitoring.MonitoringFinalizer)
 	}
-	controllerutil.RemoveFinalizer(cluster, monitoring.MonitoringFinalizer)
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR does not reconcile anything if mimir is disabled (does not try to remove finalizers and so on) to not remove PMO managed resources towards https://github.com/giantswarm/giantswarm/issues/30887

### Checklist

- [x] Update changelog in CHANGELOG.md.
