### PR TITLE
Fix missing remote write secret when head series query fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix an issue where remote-write secret was not being created when head series query fails.
+
 ## [0.1.1] - 2024-06-14
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func main() {
 	}
 
 	// Debug
-	metrics.ReconcileError.WithLabelValues("cluster", "error").Add(42)
+	metrics.ReconcileError.WithLabelValues("cluster").Add(42)
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/giantswarm/observability-operator/pkg/common"
 	"github.com/giantswarm/observability-operator/pkg/common/organization"
 	"github.com/giantswarm/observability-operator/pkg/common/password"
+	"github.com/giantswarm/observability-operator/pkg/metrics"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/heartbeat"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/prometheusagent"
@@ -224,6 +225,8 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Debug
+	metrics.ReconcileError.WithLabelValues().Add(42)
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func main() {
 	}
 
 	// Debug
-	metrics.ReconcileError.WithLabelValues("cluster").Add(42)
+	metrics.ReconcileError.WithLabelValues().Add(42)
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/main.go
+++ b/main.go
@@ -226,7 +226,7 @@ func main() {
 	}
 
 	// Debug
-	metrics.ReconcileError.WithLabelValues().Add(42)
+	metrics.ReconcileError.WithLabelValues("cluster", "error").Add(42)
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/main.go
+++ b/main.go
@@ -41,7 +41,6 @@ import (
 	"github.com/giantswarm/observability-operator/pkg/common"
 	"github.com/giantswarm/observability-operator/pkg/common/organization"
 	"github.com/giantswarm/observability-operator/pkg/common/password"
-	"github.com/giantswarm/observability-operator/pkg/metrics"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/heartbeat"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/prometheusagent"
@@ -225,8 +224,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Debug
-	metrics.ReconcileError.WithLabelValues().Add(42)
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,19 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+var (
+	ReconcileError = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "observability_operator_reconcile_error_total",
+		Help: "Total number of reconciliations error",
+	}, []string{"controller", "result"})
+)
+
+func init() {
+	metrics.Registry.MustRegister(
+		ReconcileError,
+	)
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	ReconcileError = prometheus.NewCounterVec(prometheus.CounterOpts{
+	MimirQueryErrors = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "observability_operator_mimir_head_series_query_errors_total",
 		Help: "Total number of reconciliations error",
 	}, nil)
@@ -14,6 +14,6 @@ var (
 
 func init() {
 	metrics.Registry.MustRegister(
-		ReconcileError,
+		MimirQueryErrors,
 	)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,7 +9,7 @@ var (
 	ReconcileError = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "observability_operator_reconcile_error_total",
 		Help: "Total number of reconciliations error",
-	}, []string{"controller", "result"})
+	})
 )
 
 func init() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -9,7 +9,7 @@ var (
 	ReconcileError = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "observability_operator_reconcile_error_total",
 		Help: "Total number of reconciliations error",
-	})
+	}, nil)
 )
 
 func init() {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -7,7 +7,7 @@ import (
 
 var (
 	ReconcileError = prometheus.NewCounterVec(prometheus.CounterOpts{
-		Name: "observability_operator_reconcile_error_total",
+		Name: "observability_operator_mimir_head_series_query_errors_total",
 		Help: "Total number of reconciliations error",
 	}, nil)
 )

--- a/pkg/monitoring/prometheusagent/config.go
+++ b/pkg/monitoring/prometheusagent/config.go
@@ -48,7 +48,7 @@ func (pas PrometheusAgentService) buildRemoteWriteConfig(ctx context.Context,
 	if err != nil {
 		logger.Error(err, "failed to query head series")
 	}
-	shards.ComputeShards(currentShards, headSeries)
+	shards := shards.ComputeShards(currentShards, headSeries)
 
 	config, err := yaml.Marshal(RemoteWriteConfig{
 		PrometheusAgentConfig: &PrometheusAgentConfig{

--- a/pkg/monitoring/prometheusagent/config.go
+++ b/pkg/monitoring/prometheusagent/config.go
@@ -48,7 +48,7 @@ func (pas PrometheusAgentService) buildRemoteWriteConfig(ctx context.Context,
 	headSeries, err := querier.QueryTSDBHeadSeries(ctx, cluster.Name)
 	if err != nil {
 		logger.Error(err, "failed to query head series")
-		metrics.ReconcileError.WithLabelValues().Inc()
+		metrics.MimirQueryErrors.WithLabelValues().Inc()
 	}
 	shards := shards.ComputeShards(currentShards, headSeries)
 

--- a/pkg/monitoring/prometheusagent/config.go
+++ b/pkg/monitoring/prometheusagent/config.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/giantswarm/observability-operator/pkg/common"
+	"github.com/giantswarm/observability-operator/pkg/metrics"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir/querier"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/prometheusagent/shards"
 )
@@ -47,6 +48,7 @@ func (pas PrometheusAgentService) buildRemoteWriteConfig(ctx context.Context,
 	headSeries, err := querier.QueryTSDBHeadSeries(ctx, cluster.Name)
 	if err != nil {
 		logger.Error(err, "failed to query head series")
+		metrics.ReconcileError.WithLabelValues().Inc()
 	}
 	shards := shards.ComputeShards(currentShards, headSeries)
 

--- a/pkg/monitoring/prometheusagent/config.go
+++ b/pkg/monitoring/prometheusagent/config.go
@@ -3,7 +3,6 @@ package prometheusagent
 import (
 	"context"
 	"fmt"
-	"net"
 
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
@@ -44,10 +43,12 @@ func (pas PrometheusAgentService) buildRemoteWriteConfig(ctx context.Context,
 		"service_priority": getServicePriority(cluster),
 	}
 
-	shards, err := getShardsCountForCluster(ctx, cluster, currentShards)
+	// Compute the number of shards based on the number of series.
+	headSeries, err := querier.QueryTSDBHeadSeries(ctx, cluster.Name)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		logger.Error(err, "failed to query head series")
 	}
+	shards.ComputeShards(currentShards, headSeries)
 
 	config, err := yaml.Marshal(RemoteWriteConfig{
 		PrometheusAgentConfig: &PrometheusAgentConfig{
@@ -89,21 +90,6 @@ func getServicePriority(cluster *clusterv1.Cluster) string {
 		return servicePriority
 	}
 	return defaultServicePriority
-}
-
-// We want to compute the number of shards based on the number of series.
-func getShardsCountForCluster(ctx context.Context, cluster *clusterv1.Cluster, currentShardCount int) (int, error) {
-	headSeries, err := querier.QueryTSDBHeadSeries(ctx, cluster.Name)
-	if err != nil {
-		// If Prometheus is not accessible (DNSError), or if we don't have any data yet (ErrNoTimeSeries)
-		// Then, return the default number of shards.
-		var dnsError *net.DNSError
-		if errors.As(err, &dnsError) || errors.Is(err, querier.ErrorNoTimeSeries) {
-			return shards.ComputeShards(currentShardCount, defaultShards), nil
-		}
-		return 0, errors.WithStack(err)
-	}
-	return shards.ComputeShards(currentShardCount, headSeries), nil
 }
 
 func readCurrentShardsFromConfig(configMap corev1.ConfigMap) (int, error) {


### PR DESCRIPTION
This PR fixes an issue where the remote write secret containing number of shards is not created when the query for TSDB head series fails.
It will not log the error and return a secret with default shards.