### PR TITLE
add support for Alloy as monitoring agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for Alloy to be used as monitoring agent in-place of Prometheus Agent. This is configurable via the `--monitoring-agent` flag.
+
 ## [0.3.1] - 2024-07-22
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ import (
 	"github.com/giantswarm/observability-operator/internal/controller"
 	"github.com/giantswarm/observability-operator/pkg/bundle"
 	"github.com/giantswarm/observability-operator/pkg/common"
+	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
 	"github.com/giantswarm/observability-operator/pkg/common/organization"
 	"github.com/giantswarm/observability-operator/pkg/common/password"
 	"github.com/giantswarm/observability-operator/pkg/monitoring"
@@ -111,8 +112,8 @@ func main() {
 		"The pipeline of the management cluster.")
 	flag.StringVar(&managementClusterRegion, "management-cluster-region", "",
 		"The region of the management cluster.")
-	flag.StringVar(&monitoringAgent, "monitoring-agent", common.MonitoringAgentPrometheus,
-		fmt.Sprintf("select monitoring agent to use (%s or %s)", common.MonitoringAgentPrometheus, common.MonitoringAgentAlloy)) //nolint:lll
+	flag.StringVar(&monitoringAgent, "monitoring-agent", commonmonitoring.MonitoringAgentPrometheus,
+		fmt.Sprintf("select monitoring agent to use (%s or %s)", commonmonitoring.MonitoringAgentPrometheus, commonmonitoring.MonitoringAgentAlloy)) //nolint:lll
 	flag.BoolVar(&monitoringEnabled, "monitoring-enabled", false,
 		"Enable monitoring at the management cluster level.")
 	flag.Float64Var(&monitoringShardingScaleUpSeriesCount, "monitoring-sharding-scale-up-series-count", 0,

--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 	flag.StringVar(&managementClusterRegion, "management-cluster-region", "",
 		"The region of the management cluster.")
 	flag.StringVar(&monitoringAgent, "monitoring-agent", common.MonitoringAgentPrometheus,
-		fmt.Sprintf("select monitoring agent to use (%s or %s)", common.MonitoringAgentPrometheus, common.MonitoringAgentAlloy))
+		fmt.Sprintf("select monitoring agent to use (%s or %s)", common.MonitoringAgentPrometheus, common.MonitoringAgentAlloy)) //nolint:lll
 	flag.BoolVar(&monitoringEnabled, "monitoring-enabled", false,
 		"Enable monitoring at the management cluster level.")
 	flag.Float64Var(&monitoringShardingScaleUpSeriesCount, "monitoring-sharding-scale-up-series-count", 0,

--- a/main.go
+++ b/main.go
@@ -68,6 +68,7 @@ var (
 	managementClusterPipeline   string
 	managementClusterRegion     string
 
+	monitoringAgent                       string
 	monitoringEnabled                     bool
 	monitoringShardingScaleUpSeriesCount  float64
 	monitoringShardingScaleDownPercentage float64
@@ -110,6 +111,8 @@ func main() {
 		"The pipeline of the management cluster.")
 	flag.StringVar(&managementClusterRegion, "management-cluster-region", "",
 		"The region of the management cluster.")
+	flag.StringVar(&monitoringAgent, "monitoring-agent", common.MonitoringAgentPrometheus,
+		fmt.Sprintf("select monitoring agent to use (%s or %s)", common.MonitoringAgentPrometheus, common.MonitoringAgentAlloy))
 	flag.BoolVar(&monitoringEnabled, "monitoring-enabled", false,
 		"Enable monitoring at the management cluster level.")
 	flag.Float64Var(&monitoringShardingScaleUpSeriesCount, "monitoring-sharding-scale-up-series-count", 0,
@@ -201,7 +204,8 @@ func main() {
 	organizationRepository := organization.NewNamespaceRepository(mgr.GetClient())
 
 	monitoringConfig := monitoring.Config{
-		Enabled: monitoringEnabled,
+		Enabled:         monitoringEnabled,
+		MonitoringAgent: monitoringAgent,
 		DefaultShardingStrategy: sharding.Strategy{
 			ScaleUpSeriesCount:  monitoringShardingScaleUpSeriesCount,
 			ScaleDownPercentage: monitoringShardingScaleDownPercentage,

--- a/pkg/bundle/service.go
+++ b/pkg/bundle/service.go
@@ -17,7 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	"github.com/giantswarm/observability-operator/pkg/common"
+	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
 	"github.com/giantswarm/observability-operator/pkg/monitoring"
 )
 
@@ -51,18 +51,18 @@ func (s BundleConfigurationService) Configure(ctx context.Context, cluster *clus
 	}
 
 	switch s.config.MonitoringAgent {
-	case common.MonitoringAgentPrometheus:
-		bundleConfiguration.Apps[common.MonitoringPrometheusAgentAppName] = app{
+	case commonmonitoring.MonitoringAgentPrometheus:
+		bundleConfiguration.Apps[commonmonitoring.MonitoringPrometheusAgentAppName] = app{
 			Enabled: s.config.IsMonitored(cluster),
 		}
-		bundleConfiguration.Apps[common.MonitoringAlloyAppName] = app{
+		bundleConfiguration.Apps[commonmonitoring.MonitoringAlloyAppName] = app{
 			Enabled: false,
 		}
-	case common.MonitoringAgentAlloy:
-		bundleConfiguration.Apps[common.MonitoringPrometheusAgentAppName] = app{
+	case commonmonitoring.MonitoringAgentAlloy:
+		bundleConfiguration.Apps[commonmonitoring.MonitoringPrometheusAgentAppName] = app{
 			Enabled: false,
 		}
-		bundleConfiguration.Apps[common.MonitoringAlloyAppName] = app{
+		bundleConfiguration.Apps[commonmonitoring.MonitoringAlloyAppName] = app{
 			Enabled: s.config.IsMonitored(cluster),
 		}
 	default:

--- a/pkg/bundle/service.go
+++ b/pkg/bundle/service.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/giantswarm/observability-operator/pkg/common"
 	"github.com/giantswarm/observability-operator/pkg/monitoring"
 )
 
@@ -46,11 +47,26 @@ func (s BundleConfigurationService) Configure(ctx context.Context, cluster *clus
 	logger.Info("configuring observability-bundle")
 
 	bundleConfiguration := bundleConfiguration{
-		Apps: map[string]app{
-			"prometheusAgent": {
-				Enabled: s.config.IsMonitored(cluster),
-			},
-		},
+		Apps: map[string]app{},
+	}
+
+	switch s.config.MonitoringAgent {
+	case common.MonitoringAgentPrometheus:
+		bundleConfiguration.Apps[common.MonitoringPrometheusAgentAppName] = app{
+			Enabled: s.config.IsMonitored(cluster),
+		}
+		bundleConfiguration.Apps[common.MonitoringAlloyAppName] = app{
+			Enabled: false,
+		}
+	case common.MonitoringAgentAlloy:
+		bundleConfiguration.Apps[common.MonitoringPrometheusAgentAppName] = app{
+			Enabled: false,
+		}
+		bundleConfiguration.Apps[common.MonitoringAlloyAppName] = app{
+			Enabled: s.config.IsMonitored(cluster),
+		}
+	default:
+		return errors.Errorf("unsupported monitoring agent %q", s.config.MonitoringAgent)
 	}
 
 	logger.Info("creating or updating observability-bundle configmap")

--- a/pkg/common/monitoring/monitoring.go
+++ b/pkg/common/monitoring/monitoring.go
@@ -1,0 +1,10 @@
+package monitoring
+
+const (
+	// Values accepted by the monitoring-agent flag
+	MonitoringAgentPrometheus = "prometheus-agent"
+	MonitoringAgentAlloy      = "alloy"
+	// Applications name in the observability-bundle
+	MonitoringPrometheusAgentAppName = "prometheusAgent"
+	MonitoringAlloyAppName           = "alloyMetrics"
+)

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -30,6 +30,12 @@ const (
 
 	GCPManagedClusterKind         = "GCPManagedCluster"
 	GCPManagedClusterKindProvider = "gke"
+
+	MonitoringAgentPrometheus = "prometheus-agent"
+	MonitoringAgentAlloy      = "alloy"
+
+	MonitoringPrometheusAgentAppName = "prometheusAgent"
+	MonitoringAlloyAppName           = "alloyMetrics"
 )
 
 type ManagementCluster struct {

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -30,12 +30,6 @@ const (
 
 	GCPManagedClusterKind         = "GCPManagedCluster"
 	GCPManagedClusterKindProvider = "gke"
-
-	MonitoringAgentPrometheus = "prometheus-agent"
-	MonitoringAgentAlloy      = "alloy"
-
-	MonitoringPrometheusAgentAppName = "prometheusAgent"
-	MonitoringAlloyAppName           = "alloyMetrics"
 )
 
 type ManagementCluster struct {

--- a/pkg/monitoring/config.go
+++ b/pkg/monitoring/config.go
@@ -13,6 +13,7 @@ const MonitoringLabel = "giantswarm.io/monitoring"
 // Config represents the configuration used by the monitoring package.
 type Config struct {
 	Enabled                 bool
+	MonitoringAgent         string
 	DefaultShardingStrategy sharding.Strategy
 	// TODO(atlas): validate prometheus version using SemVer
 	PrometheusVersion string


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3522

This PR add support for Alloy to be used as monitoring agent instead of Prometheus Agent. This is configurable via the `--monitoring-agent` flag in the observability-operator.

The operator will then disable Prometheus Agent and enable Alloy (the opposite is also possible) app via the observability-bundle config.