### PR TITLE
Wire Alloy service into the controller

### DIFF
--- a/helm/observability-operator/templates/deployment.yaml
+++ b/helm/observability-operator/templates/deployment.yaml
@@ -30,6 +30,7 @@ spec:
         - --management-cluster-name={{ $.Values.managementCluster.name }}
         - --management-cluster-pipeline={{ $.Values.managementCluster.pipeline }}
         - --management-cluster-region={{ $.Values.managementCluster.region }}
+        - --monitoring-agent={{ $.Values.monitoring.agent }}
         - --monitoring-enabled={{ $.Values.monitoring.enabled }}
         - --monitoring-sharding-scale-up-series-count={{ $.Values.monitoring.sharding.scaleUpSeriesCount }}
         - --monitoring-sharding-scale-down-percentage={{ $.Values.monitoring.sharding.scaleDownPercentage }}

--- a/helm/observability-operator/values.yaml
+++ b/helm/observability-operator/values.yaml
@@ -16,6 +16,7 @@ managementCluster:
   region: region
 
 monitoring:
+  agent: prometheus-agent
   enabled: false
   opsgenieApiKey: ""
   prometheusVersion: ""

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
@@ -32,10 +33,17 @@ import (
 
 	"github.com/giantswarm/observability-operator/pkg/bundle"
 	"github.com/giantswarm/observability-operator/pkg/common"
+	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
 	"github.com/giantswarm/observability-operator/pkg/monitoring"
+	"github.com/giantswarm/observability-operator/pkg/monitoring/alloy"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/heartbeat"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/prometheusagent"
+)
+
+var (
+	// TODO: change this to 1.6.0
+	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.5.0")
 )
 
 // ClusterMonitoringReconciler reconciles a Cluster object
@@ -45,6 +53,8 @@ type ClusterMonitoringReconciler struct {
 	common.ManagementCluster
 	// PrometheusAgentService is the service for managing PrometheusAgent resources.
 	prometheusagent.PrometheusAgentService
+	// AlloyService is the service which manages Alloy monitoring agent configuration.
+	AlloyService alloy.Service
 	// HeartbeatRepository is the repository for managing heartbeats.
 	heartbeat.HeartbeatRepository
 	// MimirService is the service for managing mimir configuration.
@@ -157,6 +167,21 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 		}
 	}
 
+	// Enforce prometheus-agent as monitoring agent when observability-bundle version < 1.6.0
+	monitoringAgent := r.MonitoringConfig.MonitoringAgent
+	observabilityBundleVersion, err := commonmonitoring.GetObservabilityBundleAppVersion(cluster, r.Client, ctx)
+	if err != nil {
+		logger.Error(err, "failed to configure get observability-bundle version")
+		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	}
+	if observabilityBundleVersion.LT(observabilityBundleVersionSupportAlloyMetrics) && monitoringAgent != commonmonitoring.MonitoringAgentPrometheus {
+		logger.Info("Monitoring agent is not supported by observability bundle, using prometheus-agent instead.", "observability-bundle-version", observabilityBundleVersion, "monitoring-agent", monitoringAgent)
+		monitoringAgent = commonmonitoring.MonitoringAgentPrometheus
+	}
+	r.MonitoringConfig.MonitoringAgent = monitoringAgent
+	r.BundleConfigurationService.SetMonitoringAgent(monitoringAgent)
+	r.AlloyService.SetMonitoringAgent(monitoringAgent)
+
 	// We always configure the bundle, even if monitoring is disabled for the cluster.
 	err = r.BundleConfigurationService.Configure(ctx, cluster)
 	if err != nil {
@@ -166,17 +191,36 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 
 	// Cluster specific configuration
 	if r.MonitoringConfig.IsMonitored(cluster) {
-		// Create or update PrometheusAgent remote write configuration.
-		err = r.PrometheusAgentService.ReconcileRemoteWriteConfiguration(ctx, cluster)
-		if err != nil {
-			logger.Error(err, "failed to create or update prometheus agent remote write config")
-			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+		switch r.MonitoringConfig.MonitoringAgent {
+		case commonmonitoring.MonitoringAgentPrometheus:
+			// Create or update PrometheusAgent remote write configuration.
+			err = r.PrometheusAgentService.ReconcileRemoteWriteConfiguration(ctx, cluster)
+			if err != nil {
+				logger.Error(err, "failed to create or update prometheus agent remote write config")
+				return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+			}
+		case commonmonitoring.MonitoringAgentAlloy:
+			// Create or update Alloy monitoring configuration.
+			err = r.AlloyService.ReconcileCreate(ctx, cluster)
+			if err != nil {
+				logger.Error(err, "failed to create or update alloy monitoring config")
+				return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+			}
+		default:
+			return ctrl.Result{}, errors.Errorf("unsupported monitoring agent %q", r.MonitoringConfig.MonitoringAgent)
 		}
 	} else {
 		// clean up any existing prometheus agent configuration
 		err := r.PrometheusAgentService.DeleteRemoteWriteConfiguration(ctx, cluster)
 		if err != nil {
 			logger.Error(err, "failed to delete prometheus agent remote write config")
+			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+		}
+
+		// clean up any existing alloy monitoring configuration
+		err = r.AlloyService.ReconcileDelete(ctx, cluster)
+		if err != nil {
+			logger.Error(err, "failed to delete alloy monitoring config")
 			return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 		}
 	}

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -42,8 +42,7 @@ import (
 )
 
 var (
-	// TODO: change this to 1.6.0
-	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.5.0")
+	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.6.0")
 )
 
 // ClusterMonitoringReconciler reconciles a Cluster object

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ import (
 	"github.com/giantswarm/observability-operator/pkg/common/organization"
 	"github.com/giantswarm/observability-operator/pkg/common/password"
 	"github.com/giantswarm/observability-operator/pkg/monitoring"
+	"github.com/giantswarm/observability-operator/pkg/monitoring/alloy"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/heartbeat"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/prometheusagent"
@@ -222,6 +223,14 @@ func main() {
 		MonitoringConfig:       monitoringConfig,
 	}
 
+	alloyService := alloy.Service{
+		Client:                 mgr.GetClient(),
+		OrganizationRepository: organizationRepository,
+		PasswordManager:        password.SimpleManager{},
+		ManagementCluster:      managementCluster,
+		MonitoringConfig:       monitoringConfig,
+	}
+
 	mimirService := mimir.MimirService{
 		Client:            mgr.GetClient(),
 		PasswordManager:   password.SimpleManager{},
@@ -233,6 +242,7 @@ func main() {
 		ManagementCluster:          managementCluster,
 		HeartbeatRepository:        heartbeatRepository,
 		PrometheusAgentService:     prometheusAgentService,
+		AlloyService:               alloyService,
 		MimirService:               mimirService,
 		MonitoringConfig:           monitoringConfig,
 		BundleConfigurationService: bundle.NewBundleConfigurationService(mgr.GetClient(), monitoringConfig),

--- a/pkg/bundle/service.go
+++ b/pkg/bundle/service.go
@@ -33,6 +33,10 @@ func NewBundleConfigurationService(client client.Client, config monitoring.Confi
 	}
 }
 
+func (s *BundleConfigurationService) SetMonitoringAgent(monitoringAgent string) {
+	s.config.MonitoringAgent = monitoringAgent
+}
+
 func getConfigMapObjectKey(cluster *clusterv1.Cluster) types.NamespacedName {
 	return types.NamespacedName{
 		Name:      fmt.Sprintf("%s-observability-platform-configuration", cluster.Name),
@@ -63,6 +67,7 @@ func (s BundleConfigurationService) Configure(ctx context.Context, cluster *clus
 			Enabled: false,
 		}
 		bundleConfiguration.Apps[commonmonitoring.MonitoringAlloyAppName] = app{
+			AppName: commonmonitoring.AlloyMonitoringAgentAppName,
 			Enabled: s.config.IsMonitored(cluster),
 		}
 	default:

--- a/pkg/bundle/types.go
+++ b/pkg/bundle/types.go
@@ -5,5 +5,6 @@ type bundleConfiguration struct {
 }
 
 type app struct {
-	Enabled bool `yaml:"enabled" json:"enabled"`
+	AppName string `yaml:"appName,omitempty" json:"appName,omitempty"`
+	Enabled bool   `yaml:"enabled" json:"enabled"`
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3522

This PR connects the Alloy service into the main controller to enable it.

It also adds the logic to decide between Prometheus agent and Alloy as monitoring agent.