### PR TITLE
Fix CircleCI release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,15 +35,17 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      
+
       - template-chart:
-          name: "template-chart"
+          name: template-chart
+          requires:
+            - go-build
           filters:
             branches:
               ignore:
                 - main
-          requires:
-            - "go-build"
+            tags:
+              only: /^v.*/
 
       - architect/push-to-registries:
           context: architect
@@ -67,11 +69,11 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      
+
       - architect/run-tests-with-ats:
           name: run-chart-tests-with-ats
           filters:
-            # Do not trigger the job on merge to master.
+            # Do not trigger the job on merge to main.
             branches:
               ignore:
                 - main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Disable logger development mode to avoid panicking, use zap as logger
+- Fix CircleCI release pipeline
 
 ## [0.4.0] - 2024-08-20
 


### PR DESCRIPTION
Fixes an issue where CircleCI release pipeline stopped after `go-build` step due to missing flag filter on `template-chart` step.

This mean that the v0.4.0 was not deployed anywhere currently.

### What this PR does / why we need it

* Working release pipeline on v0.3.1

![image](https://github.com/user-attachments/assets/eec335da-9727-4d7a-ba23-79af1cb9dc90)
[source](https://app.circleci.com/pipelines/github/giantswarm/observability-operator/412/workflows/732b9619-c66b-45ba-84aa-70b7145ba743)

* Broken release pipeline on v0.4.0

![image](https://github.com/user-attachments/assets/46bd26d7-9891-4fba-b519-4f2302fa6679)
[source](https://app.circleci.com/pipelines/github/giantswarm/observability-operator/577/workflows/3dd136bd-0fba-4e05-997f-cb841953cf24)


### Checklist

- [x] Update changelog in CHANGELOG.md.