### PR TITLE
Fix Alloy invalid config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix invalid Alloy config due to missing comma on external labels
+
 ## [0.4.1] - 2024-09-17
 
 ### Fixed

--- a/pkg/monitoring/alloy/templates/alloy-config.alloy.template
+++ b/pkg/monitoring/alloy/templates/alloy-config.alloy.template
@@ -51,7 +51,7 @@ prometheus.remote_write "default" {
   }
   external_labels = {
     {{- range $key, $value := .ExternalLabels }}
-    "{{ $key }}" = "{{ $value }}"
+    "{{ $key }}" = "{{ $value }}",
     {{- end }}
   }
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3522


### What this PR does / why we need it

Fixes an issue where the Alloy config is invalid due to missing commas in the external labels section.

```
$ k logs -f alloy-metrics-0
Error: /etc/alloy/config.alloy:53:27: missing ',' in field list


Error: /etc/alloy/config.alloy:54:42: missing ',' in field list

Error: /etc/alloy/config.alloy:55:30: missing ',' in field list

Error: /etc/alloy/config.alloy:56:29: missing ',' in field list

Error: /etc/alloy/config.alloy:57:34: missing ',' in field list

Error: /etc/alloy/config.alloy:58:27: missing ',' in field list

Error: /etc/alloy/config.alloy:59:24: missing ',' in field list

Error: /etc/alloy/config.alloy:60:27: missing ',' in field list

Error: /etc/alloy/config.alloy:61:35: missing ',' in field list
Error: could not perform the initial load successfully
```

### Checklist

- [x] Update changelog in CHANGELOG.md.