### PR TITLE
Require observability-bundle >= 1.6.2 for Alloy monitoring agent support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Require observability-bundle >= 1.6.2 for Alloy monitoring agent support, this is due to incorrect alloyMetrics catalog in observability-bundle
+
 ### Fixed
 
 - Fix invalid Alloy config due to missing comma on external labels

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.6.0")
+	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.6.2")
 )
 
 // ClusterMonitoringReconciler reconciles a Cluster object


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3522

Due to incorrect catalog name (giantswarm-test instead of giantswarm) in the observability-bundle (see https://github.com/giantswarm/observability-bundle/pull/241) we need to require observability-bundle >= 1.6.2 to ensure Alloy as metrics agent can be deployed correctly.