### PR TITLE
add org CRD in helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add org CRD in helm chart.
+
 ## [0.6.0] - 2024-09-24
 
 ### Added

--- a/helm/observability-operator/files/crds/organization.giantswarm.io_org.yaml
+++ b/helm/observability-operator/files/crds/organization.giantswarm.io_org.yaml
@@ -1,0 +1,96 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.8.0
+  creationTimestamp: null
+  name: org.organization.giantswarm.io
+spec:
+  group: organization.giantswarm.io
+  names:
+    kind: Org
+    listKind: OrgList
+    plural: orgs
+    singular: org
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Org is the Schema for the orgs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: OrgSpec defines the desired state of Org
+            properties:
+              displayName:
+                description: DisplayName is the displayed name of the organization. It can be different from the actual org's name.
+                type: string
+              rbac:
+                description: RBAC defines the RBAC configuration for the organization.
+                properties:
+                  description: Access role that can be assumed to access the organization
+                  properties:
+                    admins:
+                      description: Admins is a list of service accounts that have admin access to the organization.
+                      items:
+                        type: string
+                      type: array
+                    editors:
+                      description: Editors is a list of service accounts that have editor access to the organization.
+                      items:
+                        type: string
+                      type: array
+                    viewers:
+                      description: Viewers is a list of service accounts that have viewer access to the organization.
+                      items:
+                        type: string
+                      type: array
+                  required:
+                  - admins
+                  - editors
+                  - viewers
+                  type: object
+            required:
+            - displayName
+            type: object
+          status:
+            description: OrgStatus defines the observed state of Org
+            properties:
+              orgID:
+                description: OrgID is the unique id of the org.
+                type: string
+              dataSources:
+                description: DataSources is a list of grafana data sources that are available to the organization.
+                items:
+                  description: OrgDataSource defines the name and id for data sources.
+                  properties:
+                    name:
+                      description: Name is the name of the data source.
+                      type: string
+                    id:
+                      description: ID is the unique id of the data source.
+                      type: string
+                  type: object
+                type: array
+            type: object
+        type: object
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3695

This PR only adds the CRD for the organization as defined [here](https://github.com/giantswarm/roadmap/issues/3693). Follow-up PRs will be created to add the related services/controllers in the operator.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
