### PR TITLE
Fix monitoring agent race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Alloy] Fix invalid resources limits which should be equal or greater than the resources requests
+- [Alloy] Fix an issue where monitoring agent is the configured to be the same for all clusters
+
 ## [0.6.1] - 2024-10-08
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- [Alloy] Fix invalid resources limits which should be equal or greater than the resources requests
 - [Alloy] Fix an issue where monitoring agent is the configured to be the same for all clusters
 
 ## [0.6.1] - 2024-10-08

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.6.2")
+	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.6.2-78a2a259625c45011008de8dd09ac109557cec5e")
 )
 
 // ClusterMonitoringReconciler reconciles a Cluster object
@@ -173,7 +173,7 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 		logger.Error(err, "failed to configure get observability-bundle version")
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
-	if observabilityBundleVersion.LT(observabilityBundleVersionSupportAlloyMetrics) && monitoringAgent != commonmonitoring.MonitoringAgentPrometheus {
+	if observabilityBundleVersion.NE(observabilityBundleVersionSupportAlloyMetrics) && monitoringAgent != commonmonitoring.MonitoringAgentPrometheus {
 		logger.Info("Monitoring agent is not supported by observability bundle, using prometheus-agent instead.", "observability-bundle-version", observabilityBundleVersion, "monitoring-agent", monitoringAgent)
 		monitoringAgent = commonmonitoring.MonitoringAgentPrometheus
 	}

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -42,7 +42,7 @@ import (
 )
 
 var (
-	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.6.2-78a2a259625c45011008de8dd09ac109557cec5e")
+	observabilityBundleVersionSupportAlloyMetrics = semver.MustParse("1.6.2")
 )
 
 // ClusterMonitoringReconciler reconciles a Cluster object
@@ -173,7 +173,7 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 		logger.Error(err, "failed to configure get observability-bundle version")
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 	}
-	if observabilityBundleVersion.NE(observabilityBundleVersionSupportAlloyMetrics) && monitoringAgent != commonmonitoring.MonitoringAgentPrometheus {
+	if observabilityBundleVersion.LT(observabilityBundleVersionSupportAlloyMetrics) && monitoringAgent != commonmonitoring.MonitoringAgentPrometheus {
 		logger.Info("Monitoring agent is not supported by observability bundle, using prometheus-agent instead.", "observability-bundle-version", observabilityBundleVersion, "monitoring-agent", monitoringAgent)
 		monitoringAgent = commonmonitoring.MonitoringAgentPrometheus
 	}

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -177,12 +177,9 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 		logger.Info("Monitoring agent is not supported by observability bundle, using prometheus-agent instead.", "observability-bundle-version", observabilityBundleVersion, "monitoring-agent", monitoringAgent)
 		monitoringAgent = commonmonitoring.MonitoringAgentPrometheus
 	}
-	r.MonitoringConfig.MonitoringAgent = monitoringAgent
-	r.BundleConfigurationService.SetMonitoringAgent(monitoringAgent)
-	r.AlloyService.SetMonitoringAgent(monitoringAgent)
 
 	// We always configure the bundle, even if monitoring is disabled for the cluster.
-	err = r.BundleConfigurationService.Configure(ctx, cluster)
+	err = r.BundleConfigurationService.Configure(ctx, cluster, monitoringAgent)
 	if err != nil {
 		logger.Error(err, "failed to configure the observability-bundle")
 		return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
@@ -190,7 +187,7 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 
 	// Cluster specific configuration
 	if r.MonitoringConfig.IsMonitored(cluster) {
-		switch r.MonitoringConfig.MonitoringAgent {
+		switch monitoringAgent {
 		case commonmonitoring.MonitoringAgentPrometheus:
 			// Create or update PrometheusAgent remote write configuration.
 			err = r.PrometheusAgentService.ReconcileRemoteWriteConfiguration(ctx, cluster)
@@ -206,7 +203,7 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 				return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
 			}
 		default:
-			return ctrl.Result{}, errors.Errorf("unsupported monitoring agent %q", r.MonitoringConfig.MonitoringAgent)
+			return ctrl.Result{}, errors.Errorf("unsupported monitoring agent %q", monitoringAgent)
 		}
 	} else {
 		// clean up any existing prometheus agent configuration

--- a/pkg/bundle/service.go
+++ b/pkg/bundle/service.go
@@ -33,10 +33,6 @@ func NewBundleConfigurationService(client client.Client, config monitoring.Confi
 	}
 }
 
-func (s *BundleConfigurationService) SetMonitoringAgent(monitoringAgent string) {
-	s.config.MonitoringAgent = monitoringAgent
-}
-
 func getConfigMapObjectKey(cluster *clusterv1.Cluster) types.NamespacedName {
 	return types.NamespacedName{
 		Name:      fmt.Sprintf("%s-observability-platform-configuration", cluster.Name),
@@ -46,7 +42,7 @@ func getConfigMapObjectKey(cluster *clusterv1.Cluster) types.NamespacedName {
 
 // Configure configures the observability-bundle application.
 // the observabilitybundle application to enable logging agents.
-func (s BundleConfigurationService) Configure(ctx context.Context, cluster *clusterv1.Cluster) error {
+func (s BundleConfigurationService) Configure(ctx context.Context, cluster *clusterv1.Cluster, monitoringAgent string) error {
 	logger := log.FromContext(ctx)
 	logger.Info("configuring observability-bundle")
 
@@ -54,7 +50,7 @@ func (s BundleConfigurationService) Configure(ctx context.Context, cluster *clus
 		Apps: map[string]app{},
 	}
 
-	switch s.config.MonitoringAgent {
+	switch monitoringAgent {
 	case commonmonitoring.MonitoringAgentPrometheus:
 		bundleConfiguration.Apps[commonmonitoring.MonitoringPrometheusAgentAppName] = app{
 			Enabled: s.config.IsMonitored(cluster),
@@ -71,7 +67,7 @@ func (s BundleConfigurationService) Configure(ctx context.Context, cluster *clus
 			Enabled: s.config.IsMonitored(cluster),
 		}
 	default:
-		return errors.Errorf("unsupported monitoring agent %q", s.config.MonitoringAgent)
+		return errors.Errorf("unsupported monitoring agent %q", monitoringAgent)
 	}
 
 	logger.Info("creating or updating observability-bundle configmap")

--- a/pkg/monitoring/alloy/service.go
+++ b/pkg/monitoring/alloy/service.go
@@ -91,7 +91,3 @@ func (a *Service) ReconcileDelete(ctx context.Context, cluster *clusterv1.Cluste
 	logger.Info("alloy-service - ensured alloy is removed")
 	return nil
 }
-
-func (a *Service) SetMonitoringAgent(monitoringAgent string) {
-	a.MonitoringConfig.MonitoringAgent = monitoringAgent
-}

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -53,7 +53,7 @@ alloy:
     - secretRef:
         name: {{ .SecretName }}
     resources:
-      limits: {}
+      limits: null
       requests:
         cpu: {{ .RequestsCPU }}
         memory: {{ .RequestsMemory }}

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -53,6 +53,7 @@ alloy:
     - secretRef:
         name: {{ .SecretName }}
     resources:
+      limits: {}
       requests:
         cpu: {{ .RequestsCPU }}
         memory: {{ .RequestsMemory }}

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -53,7 +53,6 @@ alloy:
     - secretRef:
         name: {{ .SecretName }}
     resources:
-      limits: null
       requests:
         cpu: {{ .RequestsCPU }}
         memory: {{ .RequestsMemory }}


### PR DESCRIPTION
This PR fixes an issue which leads to all clusters being configured with the same monitoring agent, this is due to a state being persisted within the reconcile loop, this would therefore not respect the observability-bundle version requirement when configuring AlloyMetrics.