### PR TITLE
enable VPA for AlloyMetrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [Alloy] Enable VPA for AlloyMetrics
+
 ## [0.6.1] - 2024-10-08
 
 ### Fixed

--- a/pkg/common/monitoring/monitoring.go
+++ b/pkg/common/monitoring/monitoring.go
@@ -24,8 +24,6 @@ const (
 	servicePriorityLabel = "giantswarm.io/service-priority"
 
 	AlloyMonitoringAgentAppName = "alloy-metrics"
-	AlloyRequestsCPU            = "100m"
-	AlloyRequestsMemory         = "2048Mi"
 
 	// DefaultShards is the default number of shards to use.
 	DefaultShards = 1

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -80,15 +80,11 @@ func (a *Service) GenerateAlloyMonitoringConfigMapData(ctx context.Context, curr
 		AlloyConfig       string
 		PriorityClassName string
 		Replicas          int
-		RequestsCPU       string
-		RequestsMemory    string
 		SecretName        string
 	}{
 		AlloyConfig:       alloyConfig,
 		PriorityClassName: commonmonitoring.PriorityClassName,
 		Replicas:          shards,
-		RequestsCPU:       commonmonitoring.AlloyRequestsCPU,
-		RequestsMemory:    commonmonitoring.AlloyRequestsMemory,
 		SecretName:        commonmonitoring.AlloyMonitoringAgentAppName,
 	}
 

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -52,10 +52,6 @@ alloy:
     envFrom:
     - secretRef:
         name: {{ .SecretName }}
-    resources:
-      requests:
-        cpu: {{ .RequestsCPU }}
-        memory: {{ .RequestsMemory }}
   controller:
     type: statefulset
     replicas: {{ .Replicas }}
@@ -81,3 +77,15 @@ alloy:
               - alloy
           topologyKey: kubernetes.io/hostname
         weight: 50
+verticalPodAutoscaler:
+  enabled: true
+  resourcePolicy:
+    containerPolicies:
+    - containerName: alloy
+      controlledResources:
+      - memory
+      - cpu
+      controlledValues: "RequestsAndLimits"
+      minAllowed:
+        cpu: 100m
+        memory: 512Mi


### PR DESCRIPTION
The current StatefulSet requests are invalid and prevent the Pod from being scheduled due to limits being lower than requests. This PR fixes this issue by removing enabling VPA and remove requests and limits.

```
$ k describe sts alloy-metrics
...
  Warning  FailedCreate      5s (x3 over 15s)    statefulset-controller  create Pod alloy-metrics-0 in StatefulSet alloy-metrics failed error: Pod "alloy-metrics-0" is invalid: spec.containers[0].resources.requests: Invalid value: "2Gi": must be less than or equal to memory limit of 256Mi
```