### PR TITLE
Fix shards computation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Monitoring agents: keep currently configured shards when failing to compute shards
+
 ## [0.6.1] - 2024-10-08
 
 ### Fixed

--- a/pkg/common/monitoring/monitoring.go
+++ b/pkg/common/monitoring/monitoring.go
@@ -27,9 +27,6 @@ const (
 	AlloyRequestsCPU            = "100m"
 	AlloyRequestsMemory         = "2048Mi"
 
-	// DefaultShards is the default number of shards to use.
-	DefaultShards = 1
-
 	// Values accepted by the monitoring-agent flag
 	MonitoringAgentPrometheus = "prometheus-agent"
 	MonitoringAgentAlloy      = "alloy"

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -21,6 +21,7 @@ import (
 	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
 	"github.com/giantswarm/observability-operator/pkg/metrics"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir/querier"
+	"github.com/giantswarm/observability-operator/pkg/monitoring/prometheusagent/sharding"
 )
 
 var (
@@ -43,7 +44,7 @@ func (a *Service) GenerateAlloyMonitoringConfigMapData(ctx context.Context, curr
 
 	// Get current number of shards from Alloy's config.
 	// Shards here is equivalent to replicas in the Alloy controller deployment.
-	var currentShards = commonmonitoring.DefaultShards
+	var currentShards = sharding.DefaultShards
 	if currentState != nil && currentState.Data != nil && currentState.Data["values"] != "" {
 		var monitoringConfig monitoringConfig
 		err := yaml.Unmarshal([]byte(currentState.Data["values"]), &monitoringConfig)

--- a/pkg/monitoring/prometheusagent/service.go
+++ b/pkg/monitoring/prometheusagent/service.go
@@ -13,10 +13,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/giantswarm/observability-operator/pkg/common"
-	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
 	"github.com/giantswarm/observability-operator/pkg/common/organization"
 	"github.com/giantswarm/observability-operator/pkg/common/password"
 	"github.com/giantswarm/observability-operator/pkg/monitoring"
+	"github.com/giantswarm/observability-operator/pkg/monitoring/prometheusagent/sharding"
 )
 
 type PrometheusAgentService struct {
@@ -63,7 +63,7 @@ func (pas PrometheusAgentService) createOrUpdateConfigMap(ctx context.Context,
 	// Get the current configmap if it exists.
 	err := pas.Client.Get(ctx, objectKey, current)
 	if apierrors.IsNotFound(err) {
-		configMap, err := pas.buildRemoteWriteConfig(ctx, cluster, logger, commonmonitoring.DefaultShards)
+		configMap, err := pas.buildRemoteWriteConfig(ctx, cluster, logger, sharding.DefaultShards)
 		if err != nil {
 			return errors.WithStack(err)
 		}

--- a/pkg/monitoring/prometheusagent/sharding/sharding.go
+++ b/pkg/monitoring/prometheusagent/sharding/sharding.go
@@ -40,6 +40,9 @@ func (s Strategy) ComputeShards(currentShardCount int, timeSeries float64) int {
 
 	// We always have a minimum of 1 agent, even if there is no worker node
 	if desiredShardCount <= 0 {
+		if currentShardCount <= 0 {
+			return 1
+		}
 		return currentShardCount
 	}
 	return desiredShardCount

--- a/pkg/monitoring/prometheusagent/sharding/sharding.go
+++ b/pkg/monitoring/prometheusagent/sharding/sharding.go
@@ -2,8 +2,11 @@ package sharding
 
 import (
 	"math"
+)
 
-	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
+const (
+	// DefaultShards is the default number of shards to use.
+	DefaultShards = 1
 )
 
 type Strategy struct {
@@ -44,7 +47,7 @@ func (s Strategy) ComputeShards(currentShardCount int, timeSeries float64) int {
 
 	// We always have a minimum of 1 agent, even if there is no worker node
 	if desiredShardCount <= 0 {
-		return math.Max(commonmonitoring.DefaultShards, currentShardCount)
+		return int(math.Max(float64(DefaultShards), float64(currentShardCount)))
 	}
 	return desiredShardCount
 }

--- a/pkg/monitoring/prometheusagent/sharding/sharding.go
+++ b/pkg/monitoring/prometheusagent/sharding/sharding.go
@@ -40,7 +40,7 @@ func (s Strategy) ComputeShards(currentShardCount int, timeSeries float64) int {
 
 	// We always have a minimum of 1 agent, even if there is no worker node
 	if desiredShardCount <= 0 {
-		return 1
+		return currentShardCount
 	}
 	return desiredShardCount
 }

--- a/pkg/monitoring/prometheusagent/sharding/sharding.go
+++ b/pkg/monitoring/prometheusagent/sharding/sharding.go
@@ -1,6 +1,10 @@
 package sharding
 
-import "math"
+import (
+	"math"
+
+	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
+)
 
 type Strategy struct {
 	// Configures the number of series needed to add a new shard. Computation is number of series / ScaleUpSeriesCount
@@ -40,10 +44,7 @@ func (s Strategy) ComputeShards(currentShardCount int, timeSeries float64) int {
 
 	// We always have a minimum of 1 agent, even if there is no worker node
 	if desiredShardCount <= 0 {
-		if currentShardCount <= 0 {
-			return 1
-		}
-		return currentShardCount
+		return math.Max(commonmonitoring.DefaultShards, currentShardCount)
 	}
 	return desiredShardCount
 }


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/31753

This PR fixes an issue with the shards computation which lead to shards being set to 1 when querying for amount of head series fails (e.g. Mimir being down).