### PR TITLE
fix Alloy CiliumNetworkPolicy preventing alloy to reach out to pods in the cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- [Alloy] Fix CiliumNetworkPolicy to allow Alloy to reach out to every pods in the cluster
+
 ## [0.7.0] - 2024-10-10
 
 ### Changed

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -8,6 +8,7 @@ networkPolicy:
     egress:
     - toEntities:
       - kube-apiserver
+      - cluster
       - world
     - toEndpoints:
       - matchLabels:


### PR DESCRIPTION
This PR fixes the Alloy CiliumNetworkPolicy that was preventing Alloy to reach out to pods in the cluster.