### PR TITLE
Set default monitoring agent to alloy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add grafanaOrganization CRD in helm chart.
 
+### Changed
+
+- Change default default monitoring agent to Alloy
+
 ## [0.7.1] - 2024-10-10
 
 ### Fixed

--- a/main.go
+++ b/main.go
@@ -114,7 +114,7 @@ func main() {
 		"The pipeline of the management cluster.")
 	flag.StringVar(&managementClusterRegion, "management-cluster-region", "",
 		"The region of the management cluster.")
-	flag.StringVar(&monitoringAgent, "monitoring-agent", commonmonitoring.MonitoringAgentPrometheus,
+	flag.StringVar(&monitoringAgent, "monitoring-agent", commonmonitoring.MonitoringAgentAlloy,
 		fmt.Sprintf("select monitoring agent to use (%s or %s)", commonmonitoring.MonitoringAgentPrometheus, commonmonitoring.MonitoringAgentAlloy))
 	flag.BoolVar(&monitoringEnabled, "monitoring-enabled", false,
 		"Enable monitoring at the management cluster level.")


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3523

Set the default monitoring agent to Alloy so all cluster from capa v29.2.0, capz v29.1.0 will use Alloy instead of Prometheus agent.