### PR TITLE
fix flag redefined error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `flag redefined` error
+
 ## [0.8.0] - 2024-10-17
 
 ### Added

--- a/main.go
+++ b/main.go
@@ -121,8 +121,6 @@ func main() {
 		fmt.Sprintf("select monitoring agent to use (%s or %s)", commonmonitoring.MonitoringAgentPrometheus, commonmonitoring.MonitoringAgentAlloy))
 	flag.BoolVar(&monitoringEnabled, "monitoring-enabled", false,
 		"Enable monitoring at the management cluster level.")
-	flag.StringVar(&monitoringAgent, "monitoring-agent", commonmonitoring.MonitoringAgentPrometheus,
-		fmt.Sprintf("select monitoring agent to use (%s or %s)", commonmonitoring.MonitoringAgentPrometheus, commonmonitoring.MonitoringAgentAlloy))
 	flag.Float64Var(&monitoringShardingScaleUpSeriesCount, "monitoring-sharding-scale-up-series-count", 0,
 		"Configures the number of time series needed to add an extra prometheus agent shard.")
 	flag.Float64Var(&monitoringShardingScaleDownPercentage, "monitoring-sharding-scale-down-percentage", 0,


### PR DESCRIPTION
This PR fixes a runtime error due to duplicate flag definition

```
$ go run -v .
github.com/giantswarm/observability-operator
/tmp/go-build2281654998/b001/exe/observability-operator flag redefined: monitoring-agent
panic: /tmp/go-build2281654998/b001/exe/observability-operator flag redefined: monitoring-agent

goroutine 1 [running]:
flag.(*FlagSet).Var(0xc000178000, {0x1e945b0, 0x2d89ff0}, {0x1be68e5, 0x10}, {0xc0003d67c0, 0x3a})
        /home/theo/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.linux-amd64/src/flag/flag.go:1028 +0x37d
flag.StringVar(...)
        /home/theo/pkg/mod/golang.org/toolchain@v0.0.1-go1.23.2.linux-amd64/src/flag/flag.go:885
main.main()
        /home/theo/projects/observability-operator/main.go:124 +0x57c
exit status 2
```