### PR TITLE
set tenant to giantswarm

### DIFF
--- a/pkg/monitoring/alloy/templates/alloy-config.alloy.template
+++ b/pkg/monitoring/alloy/templates/alloy-config.alloy.template
@@ -36,6 +36,9 @@ prometheus.remote_write "default" {
     name = env("{{ .RemoteWriteNameEnvVarName }}")
     enable_http2 = false
     remote_timeout = "{{ .RemoteWriteTimeout }}"
+    headers = {
+      "X-Scope-OrgID" = "giantswarm",
+    }
     basic_auth {
       username = env("{{ .RemoteWriteBasicAuthUsernameEnvVarName }}")
       password = env("{{ .RemoteWriteBasicAuthPasswordEnvVarName }}")


### PR DESCRIPTION
### What this PR does / why we need it

This PR sets the metric tenant to be giantswarm by default

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
