### PR TITLE
fix loki datasource creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix exclusion check for mimir datasource to use the datasource type instead of the name.
+
 ## [0.9.0] - 2024-11-20
 
 ### Added

--- a/pkg/grafana/types.go
+++ b/pkg/grafana/types.go
@@ -34,7 +34,7 @@ func (d Datasource) buildJSONData() map[string]interface{} {
 
 func (d Datasource) buildSecureJSONData(organization Organization) map[string]string {
 	tenant := organization.TenantID
-	if d.Name != "Loki" {
+	if d.Type != "loki" {
 		// We do not support multi-tenancy for Mimir yet
 		tenant = "anonymous"
 	}


### PR DESCRIPTION
### What this PR does / why we need it

The current operator managed loki datasource is named Loki Olly Op so the condition is wrong, let's use a better validation


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
