### PR TITLE
Add support for loading dashboards in orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - command line args to configure mimir and grafana URLs
+- Support for loading dashboards in organizations
 
 ## [0.10.2] - 2024-12-17
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It reconciles `cluster.cluster.x-k8s.io` objects and makes sure each `Cluster` i
 
 ## Features
 
-### Grafan dashboards provisioning
+### Grafana dashboards provisioning
 
 It will look for kubernetes `ConfigMaps` and use them as dashboards if they meet these criteria:
 - a label `app.giantswarm.io/kind: "dashboard"`

--- a/README.md
+++ b/README.md
@@ -7,6 +7,18 @@ This operator is in charge of handling the setup and configuration of the Giant 
 It reconciles `cluster.cluster.x-k8s.io` objects and makes sure each `Cluster` is provided with:
 - TODO(atlas) update this section
 
+## Features
+
+### Grafan dashboards provisioning
+
+It will look for kubernetes `ConfigMaps` and use them as dashboards if they meet these criteria:
+- a label `app.giantswarm.io/kind: "dashboard"`
+- an annotation or label `giantswarm.io/organization` set to the organization the dasboard should be loaded in.
+
+Current limitations:
+- no support for folders
+- each dashboard belongs to one and only one organization
+
 ## Getting started
 
 Get the code and build it via:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ It reconciles `cluster.cluster.x-k8s.io` objects and makes sure each `Cluster` i
 
 It will look for kubernetes `ConfigMaps` and use them as dashboards if they meet these criteria:
 - a label `app.giantswarm.io/kind: "dashboard"`
-- an annotation or label `giantswarm.io/organization` set to the organization the dasboard should be loaded in.
+- an annotation or label `observability.giantswarm.io/organization` set to the organization the dasboard should be loaded in.
 
 Current limitations:
 - no support for folders

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/go-logr/logr v1.4.2
-	github.com/go-openapi/strfmt v0.23.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/giantswarm/apiextensions-application v0.6.2
 	github.com/go-logr/logr v1.4.2
+	github.com/go-openapi/strfmt v0.23.0
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20250108132429-8d7e1f158f65
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
@@ -99,7 +100,6 @@ require (
 	github.com/go-openapi/loads v0.22.0 // indirect
 	github.com/go-openapi/runtime v0.28.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
-	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -100,6 +100,7 @@ require (
 	github.com/go-openapi/loads v0.22.0 // indirect
 	github.com/go-openapi/runtime v0.28.0 // indirect
 	github.com/go-openapi/spec v0.21.0 // indirect
+	github.com/go-openapi/strfmt v0.23.0 // indirect
 	github.com/go-openapi/validate v0.24.0 // indirect
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -205,15 +205,15 @@ func getDashboardUID(jsonDashboard string) (string, error) {
 func getDashboardCMOrg(dashboard *v1.ConfigMap) (string, error) {
 
 	// Try to look for an annotation first
-	orgName, ok := dashboard.GetAnnotations()[organization.OrganizationLabel]
-	if ok && orgName != "" {
-		return orgName, nil
+	annotations := dashboard.GetAnnotations()
+	if annotations != nil && annotations[organization.OrganizationLabel] != "" {
+		return annotations[organization.OrganizationLabel], nil
 	}
 
 	// Then look for a label
-	orgName, ok = dashboard.GetLabels()[organization.OrganizationLabel]
-	if ok && orgName != "" {
-		return orgName, nil
+	labels := dashboard.GetLabels()
+	if labels != nil && labels[organization.OrganizationLabel] != "" {
+		return labels[organization.OrganizationLabel], nil
 	}
 
 	// Return an error if no label was found

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -1,0 +1,344 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-openapi/strfmt"
+	grafanaAPI "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/pkg/errors"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/cluster-api/util/patch"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/giantswarm/observability-operator/pkg/config"
+	"github.com/giantswarm/observability-operator/pkg/grafana"
+	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
+
+	"github.com/giantswarm/observability-operator/internal/controller/predicates"
+)
+
+// DashboardReconciler reconciles a Dashboard object
+type DashboardReconciler struct {
+	client.Client
+	Scheme     *runtime.Scheme
+	GrafanaAPI *grafanaAPI.GrafanaHTTPAPI
+}
+
+const (
+	DashboardFinalizer      = "observability.giantswarm.io/grafanadashboard"
+	DashboardTeamAnnotation = "giantswarm.io/organization"
+)
+
+func SetupDashboardReconciler(mgr manager.Manager, conf config.Config) error {
+	// Generate Grafana client
+	// Get grafana admin-password and admin-user
+	grafanaAdminCredentials := grafanaclient.AdminCredentials{
+		Username: conf.Environment.GrafanaAdminUsername,
+		Password: conf.Environment.GrafanaAdminPassword,
+	}
+	if grafanaAdminCredentials.Username == "" {
+		return fmt.Errorf("GrafanaAdminUsername not set: %q", conf.Environment.GrafanaAdminUsername)
+	}
+	if grafanaAdminCredentials.Password == "" {
+		return fmt.Errorf("GrafanaAdminPassword not set: %q", conf.Environment.GrafanaAdminPassword)
+	}
+
+	grafanaTLSConfig := grafanaclient.TLSConfig{
+		Cert: conf.Environment.GrafanaTLSCertFile,
+		Key:  conf.Environment.GrafanaTLSKeyFile,
+	}
+	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, grafanaAdminCredentials, grafanaTLSConfig)
+	if err != nil {
+		return fmt.Errorf("unable to create grafana client: %w", err)
+	}
+
+	r := &DashboardReconciler{
+		Client:     mgr.GetClient(),
+		Scheme:     mgr.GetScheme(),
+		GrafanaAPI: grafanaAPI,
+	}
+
+	err = r.SetupWithManager(mgr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+//+kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=core,resources=configmaps/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=core,resources=configmaps/finalizers,verbs=update
+
+// Reconcile is part of the main Kubernetes reconciliation loop which aims to
+// move the current state of the Dashboard closer to the desired state.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.0/pkg/reconcile
+func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	logger.Info("Started reconciling Grafana Dashboard Configmaps")
+	defer logger.Info("Finished reconciling Grafana Dashboard Configmaps")
+
+	dashboard := &v1.ConfigMap{}
+	err := r.Client.Get(ctx, req.NamespacedName, dashboard)
+	if err != nil {
+		return ctrl.Result{}, errors.WithStack(client.IgnoreNotFound(err))
+	}
+
+	// Handle deleted grafana dashboards
+	if !dashboard.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, r.reconcileDelete(ctx, dashboard)
+	}
+
+	// Handle non-deleted grafana dashboards
+	return r.reconcileCreate(ctx, dashboard)
+}
+
+// SetupWithManager sets up the controller with the Manager.
+func (r *DashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
+
+	labelSelectorPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{"app.giantswarm.io/kind": "dashboard"}})
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.ConfigMap{}, builder.WithPredicates(labelSelectorPredicate)).
+		// Watch for grafana pod's status changes
+		Watches(
+			&v1.Pod{},
+			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+				var logger = log.FromContext(ctx)
+				var dashboards v1.ConfigMapList
+
+				err := mgr.GetClient().List(ctx, &dashboards, client.MatchingLabels{"app.giantswarm.io/kind": "dashboard"})
+				if err != nil {
+					logger.Error(err, "failed to list grafana dashboard configmaps")
+					return []reconcile.Request{}
+				}
+
+				// Reconcile all grafana dashboards when the grafana pod is recreated
+				requests := make([]reconcile.Request, 0, len(dashboards.Items))
+				for _, dashboard := range dashboards.Items {
+					requests = append(requests, reconcile.Request{
+						NamespacedName: types.NamespacedName{
+							Name: dashboard.Name,
+						},
+					})
+				}
+				return requests
+			}),
+			builder.WithPredicates(predicates.GrafanaPodRecreatedPredicate{}),
+		).
+		Complete(r)
+}
+
+// reconcileCreate creates the dashboard.
+// reconcileCreate ensures the Grafana dashboard described in configmap is created in Grafana.
+// This function is also responsible for:
+// - Adding the finalizer to the configmap
+func (r DashboardReconciler) reconcileCreate(ctx context.Context, dashboard *v1.ConfigMap) (ctrl.Result, error) { // nolint:unparam
+	logger := log.FromContext(ctx)
+
+	// Add finalizer first if not set to avoid the race condition between init and delete.
+	if !controllerutil.ContainsFinalizer(dashboard, DashboardFinalizer) {
+		// We use a patch rather than an update to avoid conflicts when multiple controllers are adding their finalizer to the grafana dashboard
+		// We use the patch from sigs.k8s.io/cluster-api/util/patch to handle the patching without conflicts
+		logger.Info("adding finalizer", "finalizer", DashboardFinalizer)
+		patchHelper, err := patch.NewHelper(dashboard, r.Client)
+		if err != nil {
+			return ctrl.Result{}, errors.WithStack(err)
+		}
+		controllerutil.AddFinalizer(dashboard, DashboardFinalizer)
+		if err := patchHelper.Patch(ctx, dashboard); err != nil {
+			logger.Error(err, "failed to add finalizer", "finalizer", DashboardFinalizer)
+			return ctrl.Result{}, errors.WithStack(err)
+		}
+		logger.Info("added finalizer", "finalizer", DashboardFinalizer)
+		return ctrl.Result{}, nil
+	}
+
+	// Configure the dashboard in Grafana
+	if err := r.configureDashboard(ctx, dashboard); err != nil {
+		return ctrl.Result{}, errors.WithStack(err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func getDashboardUID(jsonDashboard string) (UID string, err error) {
+
+	var Dashboard map[string]interface{}
+	err = json.Unmarshal([]byte(jsonDashboard), &Dashboard)
+	if err != nil {
+		return "", err
+	}
+
+	UID, ok := Dashboard["uid"].(string)
+	if !ok {
+		return "", errors.New("dashboard UID not found in configmap")
+	}
+	return UID, nil
+}
+
+func getDashboardCMOrg(dashboard *v1.ConfigMap) (Org string, err error) {
+
+	// Try to look for an annotation first
+	orgName := dashboard.GetAnnotations()[DashboardTeamAnnotation]
+	if orgName != "" {
+		return orgName, nil
+	}
+
+	// Then look for a label
+	orgName = dashboard.GetLabels()[DashboardTeamAnnotation]
+
+	if orgName != "" {
+		return orgName, nil
+	}
+
+	// Return an error if no label was found
+	return "", errors.New("No organization label found in configmap")
+}
+
+func (r DashboardReconciler) configureDashboard(ctx context.Context, dashboardCM *v1.ConfigMap) (err error) {
+	logger := log.FromContext(ctx)
+
+	dashboardOrg, err := getDashboardCMOrg(dashboardCM)
+	if err != nil {
+		logger.Info("Skipping dashboard, no organization found")
+		return nil
+	}
+
+	// We always switch back to the shared org
+	defer func() {
+		if _, err = r.GrafanaAPI.SignedInUser.UserSetUsingOrg(grafana.SharedOrg.ID); err != nil {
+			logger.Error(err, "failed to change current org for signed in user")
+		}
+	}()
+
+	for _, dashboard := range dashboardCM.Data {
+		dashboardUID, err := getDashboardUID(dashboard)
+		if err != nil {
+			logger.Info("Skipping dashboard, no UID found")
+			continue
+		}
+		// Switch context to the current org
+		organization, err := grafana.FindOrgByName(r.GrafanaAPI, dashboardOrg)
+		if err != nil {
+			logger.Error(err, "failed to find organization", "organization", dashboardOrg)
+			return errors.WithStack(err)
+		}
+		logger.Info("Found dashboard org", "Organization", organization)
+
+		if _, err = r.GrafanaAPI.SignedInUser.UserSetUsingOrg(organization.ID); err != nil {
+			logger.Error(err, "failed to change current org for signed in user")
+			return errors.WithStack(err)
+		}
+
+		var dashboardjson interface{}
+		err = json.Unmarshal([]byte(dashboard), &dashboardjson)
+		if err != nil {
+			logger.Info("Failed converting dashboard to json")
+			return errors.WithStack(err)
+		}
+
+		// Create or update dashboard
+		_, err = r.GrafanaAPI.Dashboards.PostDashboard(&models.SaveDashboardCommand{
+			UpdatedAt: strfmt.DateTime(time.Now()),
+			Dashboard: dashboardjson,
+			FolderID:  0,
+			FolderUID: "",
+			IsFolder:  false,
+			Message:   "Added by observability-operator",
+			Overwrite: true,
+			UserID:    0,
+		})
+		if err != nil {
+			logger.Info("Failed updating dashboard")
+			return errors.WithStack(err)
+		}
+
+		logger.Info("updated dashboard", "Dashboard UID", dashboardUID, "Dashboard Org", dashboardOrg)
+	}
+
+	// return nil
+	return errors.New("All good, but not implemented yet")
+}
+
+// reconcileDelete deletes the grafana dashboard.
+func (r DashboardReconciler) reconcileDelete(ctx context.Context, dashboardCM *v1.ConfigMap) error {
+	logger := log.FromContext(ctx)
+
+	// We do not need to delete anything if there is no finalizer on the grafana dashboard
+	if !controllerutil.ContainsFinalizer(dashboardCM, DashboardFinalizer) {
+		return nil
+	}
+
+	dashboardOrg, err := getDashboardCMOrg(dashboardCM)
+	if err != nil {
+		logger.Info("Skipping dashboard, no organization found")
+		return nil
+	}
+
+	for _, dashboard := range dashboardCM.Data {
+		dashboardUID, err := getDashboardUID(dashboard)
+		if err != nil {
+			logger.Info("Skipping dashboard, no UID found")
+			continue
+		}
+
+		// TODO: search for dashboard by ID
+		// TODO: delete dashboard if it exits
+		logger.Info("deleted dashboard", "Dashboard UID", dashboardUID, "Dashboard Org", dashboardOrg)
+	}
+
+	// Finalizer handling needs to come last.
+	// We use the patch from sigs.k8s.io/cluster-api/util/patch to handle the patching without conflicts
+	logger.Info("removing finalizer", "finalizer", DashboardFinalizer)
+	patchHelper, err := patch.NewHelper(dashboardCM, r.Client)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	controllerutil.RemoveFinalizer(dashboardCM, DashboardFinalizer)
+	if err := patchHelper.Patch(ctx, dashboardCM); err != nil {
+		logger.Error(err, "failed to remove finalizer, requeuing", "finalizer", DashboardFinalizer)
+		return errors.WithStack(err)
+	}
+	logger.Info("removed finalizer", "finalizer", DashboardFinalizer)
+
+	return nil
+}

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -44,24 +44,7 @@ const (
 )
 
 func SetupDashboardReconciler(mgr manager.Manager, conf config.Config) error {
-	// Generate Grafana client
-	// Get grafana admin-password and admin-user
-	grafanaAdminCredentials := grafanaclient.AdminCredentials{
-		Username: conf.Environment.GrafanaAdminUsername,
-		Password: conf.Environment.GrafanaAdminPassword,
-	}
-	if grafanaAdminCredentials.Username == "" {
-		return fmt.Errorf("GrafanaAdminUsername not set: %q", conf.Environment.GrafanaAdminUsername)
-	}
-	if grafanaAdminCredentials.Password == "" {
-		return fmt.Errorf("GrafanaAdminPassword not set: %q", conf.Environment.GrafanaAdminPassword)
-	}
-
-	grafanaTLSConfig := grafanaclient.TLSConfig{
-		Cert: conf.Environment.GrafanaTLSCertFile,
-		Key:  conf.Environment.GrafanaTLSKeyFile,
-	}
-	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, grafanaAdminCredentials, grafanaTLSConfig)
+	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, conf)
 	if err != nil {
 		return fmt.Errorf("unable to create grafana client: %w", err)
 	}

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -113,7 +113,6 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *DashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
-
 	labelSelectorPredicate, err := predicate.LabelSelectorPredicate(metav1.LabelSelector{MatchLabels: map[string]string{DashboardSelectorLabelName: DashboardSelectorLabelValue}})
 	if err != nil {
 		return errors.WithStack(err)
@@ -186,7 +185,6 @@ func (r DashboardReconciler) reconcileCreate(ctx context.Context, dashboard *v1.
 }
 
 func getDashboardUID(dashboard map[string]interface{}) (string, error) {
-
 	UID, ok := dashboard["uid"].(string)
 	if !ok {
 		return "", errors.New("dashboard UID not found in configmap")
@@ -195,7 +193,6 @@ func getDashboardUID(dashboard map[string]interface{}) (string, error) {
 }
 
 func getDashboardCMOrg(dashboard *v1.ConfigMap) (string, error) {
-
 	// Try to look for an annotation first
 	annotations := dashboard.GetAnnotations()
 	if annotations != nil && annotations[organization.OrganizationLabel] != "" {
@@ -240,7 +237,6 @@ func (r DashboardReconciler) configureDashboard(ctx context.Context, dashboardCM
 	}
 
 	for _, dashboardString := range dashboardCM.Data {
-
 		var dashboard map[string]any
 		err = json.Unmarshal([]byte(dashboardString), &dashboard)
 		if err != nil {

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -191,7 +191,7 @@ func getDashboardUID(dashboard map[string]interface{}) (string, error) {
 	return UID, nil
 }
 
-func getDashboardCMOrg(dashboard *v1.ConfigMap) (string, error) {
+func getOrgFromDashboardConfigmap(dashboard *v1.ConfigMap) (string, error) {
 	// Try to look for an annotation first
 	annotations := dashboard.GetAnnotations()
 	if annotations != nil && annotations[organization.OrganizationLabel] != "" {
@@ -211,7 +211,7 @@ func getDashboardCMOrg(dashboard *v1.ConfigMap) (string, error) {
 func (r DashboardReconciler) configureDashboard(ctx context.Context, dashboardCM *v1.ConfigMap) error {
 	logger := log.FromContext(ctx)
 
-	dashboardOrg, err := getDashboardCMOrg(dashboardCM)
+	dashboardOrg, err := getOrgFromDashboardConfigmap(dashboardCM)
 	if err != nil {
 		logger.Error(err, "Skipping dashboard, no organization found")
 		return nil
@@ -271,7 +271,7 @@ func (r DashboardReconciler) reconcileDelete(ctx context.Context, dashboardCM *v
 		return nil
 	}
 
-	dashboardOrg, err := getDashboardCMOrg(dashboardCM)
+	dashboardOrg, err := getOrgFromDashboardConfigmap(dashboardCM)
 	if err != nil {
 		logger.Error(err, "Skipping dashboard, no organization found")
 		return nil

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -213,7 +213,7 @@ func (r DashboardReconciler) configureDashboard(ctx context.Context, dashboardCM
 
 	dashboardOrg, err := getDashboardCMOrg(dashboardCM)
 	if err != nil {
-		logger.Info("Skipping dashboard, no organization found")
+		logger.Error(err, "Skipping dashboard, no organization found")
 		return nil
 	}
 
@@ -239,20 +239,20 @@ func (r DashboardReconciler) configureDashboard(ctx context.Context, dashboardCM
 		var dashboard map[string]any
 		err = json.Unmarshal([]byte(dashboardString), &dashboard)
 		if err != nil {
-			logger.Info("Failed converting dashboard to json", "Error", err)
+			logger.Error(err, "Failed converting dashboard to json")
 			continue
 		}
 
 		dashboardUID, err := getDashboardUID(dashboard)
 		if err != nil {
-			logger.Info("Skipping dashboard, no UID found")
+			logger.Error(err, "Skipping dashboard, no UID found")
 			continue
 		}
 
 		// Create or update dashboard
 		err = grafana.PublishDashboard(r.GrafanaAPI, dashboard)
 		if err != nil {
-			logger.Info("Failed updating dashboard", "Error", err)
+			logger.Error(err, "Failed updating dashboard")
 			continue
 		}
 
@@ -273,7 +273,7 @@ func (r DashboardReconciler) reconcileDelete(ctx context.Context, dashboardCM *v
 
 	dashboardOrg, err := getDashboardCMOrg(dashboardCM)
 	if err != nil {
-		logger.Info("Skipping dashboard, no organization found")
+		logger.Error(err, "Skipping dashboard, no organization found")
 		return nil
 	}
 
@@ -299,27 +299,25 @@ func (r DashboardReconciler) reconcileDelete(ctx context.Context, dashboardCM *v
 		var dashboard map[string]interface{}
 		err = json.Unmarshal([]byte(dashboardString), &dashboard)
 		if err != nil {
-			logger.Info("Failed converting dashboard to json", "Error", err)
+			logger.Error(err, "Failed converting dashboard to json")
 			continue
 		}
 
 		dashboardUID, err := getDashboardUID(dashboard)
 		if err != nil {
-			logger.Info("Skipping dashboard, no UID found")
+			logger.Error(err, "Skipping dashboard, no UID found")
 			continue
 		}
 
-		// TODO: search for dashboard by ID
 		_, err = r.GrafanaAPI.Dashboards.GetDashboardByUID(dashboardUID)
 		if err != nil {
-			logger.Info("Failed getting dashboard", "Error", err)
+			logger.Error(err, "Failed getting dashboard")
 			continue
 		}
 
-		// TODO: delete dashboard if it exits
 		_, err = r.GrafanaAPI.Dashboards.DeleteDashboardByUID(dashboardUID)
 		if err != nil {
-			logger.Info("Failed deleting dashboard", "Error", err)
+			logger.Error(err, "Failed deleting dashboard")
 			continue
 		}
 

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	grafanaAPI "github.com/grafana/grafana-openapi-client-go/client"
-	"github.com/grafana/grafana-openapi-client-go/models"
 	"github.com/pkg/errors"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -251,11 +250,7 @@ func (r DashboardReconciler) configureDashboard(ctx context.Context, dashboardCM
 		}
 
 		// Create or update dashboard
-		_, err = r.GrafanaAPI.Dashboards.PostDashboard(&models.SaveDashboardCommand{
-			Dashboard: any(dashboard),
-			Message:   "Added by observability-operator",
-			Overwrite: true, // allows dashboard to be updated by the same UID
-		})
+		err = grafana.PublishDashboard(r.GrafanaAPI, dashboard)
 		if err != nil {
 			logger.Info("Failed updating dashboard", "Error", err)
 			continue

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -22,7 +22,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/giantswarm/observability-operator/pkg/common/organization"
 	"github.com/giantswarm/observability-operator/pkg/config"
 	"github.com/giantswarm/observability-operator/pkg/grafana"
 	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
@@ -41,6 +40,7 @@ const (
 	DashboardFinalizer          = "observability.giantswarm.io/grafanadashboard"
 	DashboardSelectorLabelName  = "app.giantswarm.io/kind"
 	DashboardSelectorLabelValue = "dashboard"
+	grafanaOrganizationLabel    = "observability.giantswarm.io/organization"
 )
 
 func SetupDashboardReconciler(mgr manager.Manager, conf config.Config) error {
@@ -177,14 +177,14 @@ func getDashboardUID(dashboard map[string]interface{}) (string, error) {
 func getOrgFromDashboardConfigmap(dashboard *v1.ConfigMap) (string, error) {
 	// Try to look for an annotation first
 	annotations := dashboard.GetAnnotations()
-	if annotations != nil && annotations[organization.OrganizationLabel] != "" {
-		return annotations[organization.OrganizationLabel], nil
+	if annotations != nil && annotations[grafanaOrganizationLabel] != "" {
+		return annotations[grafanaOrganizationLabel], nil
 	}
 
 	// Then look for a label
 	labels := dashboard.GetLabels()
-	if labels != nil && labels[organization.OrganizationLabel] != "" {
-		return labels[organization.OrganizationLabel], nil
+	if labels != nil && labels[grafanaOrganizationLabel] != "" {
+		return labels[grafanaOrganizationLabel], nil
 	}
 
 	// Return an error if no label was found

--- a/internal/controller/dashboard_controller_test.go
+++ b/internal/controller/dashboard_controller_test.go
@@ -1,19 +1,3 @@
-/*
-Copyright 2024.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controller
 
 import (

--- a/internal/controller/dashboard_controller_test.go
+++ b/internal/controller/dashboard_controller_test.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2024.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+)
+
+var _ = Describe("Dashboard Controller", func() {
+	Context("When reconciling a resource", func() {
+
+		It("should successfully reconcile the resource", func() {
+
+			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
+			// Example: If you expect a certain status condition after reconciliation, verify it here.
+		})
+	})
+})

--- a/internal/controller/dashboard_controller_test.go
+++ b/internal/controller/dashboard_controller_test.go
@@ -6,9 +6,7 @@ import (
 
 var _ = Describe("Dashboard Controller", func() {
 	Context("When reconciling a resource", func() {
-
 		It("should successfully reconcile the resource", func() {
-
 			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
 			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -39,25 +39,7 @@ type GrafanaOrganizationReconciler struct {
 }
 
 func SetupGrafanaOrganizationReconciler(mgr manager.Manager, conf config.Config) error {
-	// Generate Grafana client
-
-	// Get grafana admin-password and admin-user
-	grafanaAdminCredentials := grafanaclient.AdminCredentials{
-		Username: conf.Environment.GrafanaAdminUsername,
-		Password: conf.Environment.GrafanaAdminPassword,
-	}
-	if grafanaAdminCredentials.Username == "" {
-		return fmt.Errorf("GrafanaAdminUsername not set: %q", conf.Environment.GrafanaAdminUsername)
-	}
-	if grafanaAdminCredentials.Password == "" {
-		return fmt.Errorf("GrafanaAdminPassword not set: %q", conf.Environment.GrafanaAdminPassword)
-	}
-
-	grafanaTLSConfig := grafanaclient.TLSConfig{
-		Cert: conf.Environment.GrafanaTLSCertFile,
-		Key:  conf.Environment.GrafanaTLSKeyFile,
-	}
-	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, grafanaAdminCredentials, grafanaTLSConfig)
+	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, conf)
 	if err != nil {
 		return fmt.Errorf("unable to create grafana client: %w", err)
 	}

--- a/main.go
+++ b/main.go
@@ -197,7 +197,6 @@ func main() {
 			os.Exit(1)
 		}
 	}
-	//+kubebuilder:scaffold:builder
 
 	err = controller.SetupDashboardReconciler(mgr, conf)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -199,6 +199,13 @@ func main() {
 	}
 	//+kubebuilder:scaffold:builder
 
+	err = controller.SetupDashboardReconciler(mgr, conf)
+	if err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "Dashboard")
+		os.Exit(1)
+	}
+	//+kubebuilder:scaffold:builder
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		os.Exit(1)

--- a/pkg/common/organization/repository.go
+++ b/pkg/common/organization/repository.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	organizationLabel string = "giantswarm.io/organization"
+	OrganizationLabel string = "giantswarm.io/organization"
 )
 
 type OrganizationRepository interface {
@@ -32,7 +32,7 @@ func (r NamespaceOrganizationRepository) Read(ctx context.Context, cluster *clus
 		return "", err
 	}
 
-	if organization, ok := namespace.Labels[organizationLabel]; ok {
+	if organization, ok := namespace.Labels[OrganizationLabel]; ok {
 		return organization, nil
 	}
 	return "", errors.New("cluster namespace missing organization label")

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -324,3 +324,14 @@ func FindOrgByID(grafanaAPI *client.GrafanaHTTPAPI, orgID int64) (*Organization,
 		Name: organization.Payload.Name,
 	}, nil
 }
+
+// PublishDashboard creates or updates a dashboard in Grafana
+func PublishDashboard(grafanaAPI *client.GrafanaHTTPAPI, dashboard map[string]any) error {
+	_, err := grafanaAPI.Dashboards.PostDashboard(&models.SaveDashboardCommand{
+		Dashboard: any(dashboard),
+		Message:   "Added by observability-operator",
+		Overwrite: true, // allows dashboard to be updated by the same UID
+
+	})
+	return err
+}

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -95,7 +95,7 @@ func UpdateOrganization(ctx context.Context, grafanaAPI *client.GrafanaHTTPAPI, 
 	logger := log.FromContext(ctx)
 
 	logger.Info("updating organization")
-	found, err := findByID(grafanaAPI, organization.ID)
+	found, err := FindOrgByID(grafanaAPI, organization.ID)
 	if err != nil {
 		if isNotFound(err) {
 			logger.Info("organization id not found, creating")
@@ -135,7 +135,7 @@ func DeleteOrganization(ctx context.Context, grafanaAPI *client.GrafanaHTTPAPI, 
 	logger := log.FromContext(ctx)
 
 	logger.Info("deleting organization")
-	_, err := findByID(grafanaAPI, organization.ID)
+	_, err := FindOrgByID(grafanaAPI, organization.ID)
 	if err != nil {
 		if isNotFound(err) {
 			logger.Info("organization id was not found, skipping deletion")
@@ -282,7 +282,7 @@ func isNotFound(err error) bool {
 func assertNameIsAvailable(ctx context.Context, grafanaAPI *client.GrafanaHTTPAPI, organization *Organization) error {
 	logger := log.FromContext(ctx)
 
-	found, err := findByName(grafanaAPI, organization.Name)
+	found, err := FindOrgByName(grafanaAPI, organization.Name)
 	if err != nil {
 		// We only error if we have any error other than a 404
 		if !isNotFound(err) {
@@ -299,8 +299,8 @@ func assertNameIsAvailable(ctx context.Context, grafanaAPI *client.GrafanaHTTPAP
 	return nil
 }
 
-// findByName is a wrapper function used to find a Grafana organization by its name
-func findByName(grafanaAPI *client.GrafanaHTTPAPI, name string) (*Organization, error) {
+// FindOrgByName is a wrapper function used to find a Grafana organization by its name
+func FindOrgByName(grafanaAPI *client.GrafanaHTTPAPI, name string) (*Organization, error) {
 	organization, err := grafanaAPI.Orgs.GetOrgByName(name)
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -312,8 +312,8 @@ func findByName(grafanaAPI *client.GrafanaHTTPAPI, name string) (*Organization, 
 	}, nil
 }
 
-// findByID is a wrapper function used to find a Grafana organization by its id
-func findByID(grafanaAPI *client.GrafanaHTTPAPI, orgID int64) (*Organization, error) {
+// FindOrgByID is a wrapper function used to find a Grafana organization by its id
+func FindOrgByID(grafanaAPI *client.GrafanaHTTPAPI, orgID int64) (*Organization, error) {
 	organization, err := grafanaAPI.Orgs.GetOrgByID(orgID)
 	if err != nil {
 		return nil, errors.WithStack(err)


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3696

Support loading dashboards in organizations.

Extract from README telling about this feature:

> It will look for kubernetes `ConfigMaps` and use them as dashboards if they meet these criteria:
> - a label `app.giantswarm.io/kind: "dashboard"`
> - an annotation or label `giantswarm.io/organization` set to the organization the dasboard should be loaded in.
> 
> Current limitations:
> - no support for folders
> - each dashboard belongs to one and only one organization


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
