### PR TITLE
Add Mimir Alertmanager datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Mimir Alertmanager datasource
+
 ## [0.9.1] - 2024-11-21
 
 ### Fixed

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -37,6 +37,17 @@ var defaultDatasources = []Datasource{
 		},
 	},
 	{
+		Name:      "Mimir Alertmanager",
+		Type:      "alertmanager",
+		IsDefault: false,
+		URL:       "http://mimir-alertmanager.mimir.svc:8080",
+		Access:    datasourceProxyAccessMode,
+		JSONData: map[string]interface{}{
+			"handleGrafanaManagedAlerts": false,
+			"implementation":             "mimir",
+		},
+	},
+	{
 		Name:      "Mimir olly-op",
 		Type:      "prometheus",
 		IsDefault: true,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/roadmap/issues/3746

This PR adds the Grafana datasource for Mimir's Alertmanager in order to be able to view Alerts, notifications policies, silences and all sort of alertmanager related informations from Grafana.