### PR TITLE
prevent empty grafana configmap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add Mimir Alertmanager datasource
 
+### Changed
+
+- Removed organization OwnerReference on grafana-user-values configmap, this fixes an issue where the configmap is removed when the last organization is deleted which prevent Grafana from starting.
+
 ## [0.9.1] - 2024-11-21
 
 ### Fixed

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -332,14 +332,6 @@ func (r *GrafanaOrganizationReconciler) configureGrafana(ctx context.Context) er
 			return errors.WithStack(err)
 		}
 
-		for _, organization := range organizations {
-			// Set owner reference to the config map to be able to clean it up when all organizations are deleted
-			err = controllerutil.SetOwnerReference(&organization, grafanaConfig, r.Scheme)
-			if err != nil {
-				return errors.WithStack(err)
-			}
-		}
-
 		logger.Info("updating grafana-user-values", "config", config)
 
 		grafanaConfig.Data = make(map[string]string)

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -332,6 +332,15 @@ func (r *GrafanaOrganizationReconciler) configureGrafana(ctx context.Context) er
 			return errors.WithStack(err)
 		}
 
+		// cleanup owner references from the config map - to be removed for next release
+		for _, organization := range organizations {
+			err = controllerutil.RemoveOwnerReference(&organization, grafanaConfig, r.Scheme)
+			if err != nil {
+				// ignore errors, omner references are probably already gone
+				continue
+			}
+		}
+
 		logger.Info("updating grafana-user-values", "config", config)
 
 		grafanaConfig.Data = make(map[string]string)

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -334,11 +334,8 @@ func (r *GrafanaOrganizationReconciler) configureGrafana(ctx context.Context) er
 
 		// cleanup owner references from the config map - TODO: to be removed for next release
 		for _, organization := range organizations {
-			err = controllerutil.RemoveOwnerReference(&organization, grafanaConfig, r.Scheme)
-			if err != nil {
-				// ignore errors, omner references are probably already gone
-				continue
-			}
+			// nolint:errcheck,gosec // ignore errors, owner references are probably already gone
+			controllerutil.RemoveOwnerReference(&organization, grafanaConfig, r.Scheme)
 		}
 
 		logger.Info("updating grafana-user-values", "config", config)

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -332,7 +332,8 @@ func (r *GrafanaOrganizationReconciler) configureGrafana(ctx context.Context) er
 			return errors.WithStack(err)
 		}
 
-		// cleanup owner references from the config map - TODO: to be removed for next release
+		// TODO: to be removed for next release
+		// cleanup owner references from the config map, see https://github.com/giantswarm/observability-operator/pull/183
 		for _, organization := range organizations {
 			// nolint:errcheck,gosec // ignore errors, owner references are probably already gone
 			controllerutil.RemoveOwnerReference(&organization, grafanaConfig, r.Scheme)

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -332,7 +332,7 @@ func (r *GrafanaOrganizationReconciler) configureGrafana(ctx context.Context) er
 			return errors.WithStack(err)
 		}
 
-		// cleanup owner references from the config map - to be removed for next release
+		// cleanup owner references from the config map - TODO: to be removed for next release
 		for _, organization := range organizations {
 			err = controllerutil.RemoveOwnerReference(&organization, grafanaConfig, r.Scheme)
 			if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it

When removing all organizations, grafana-user-values gets deleted, which prevents grafana app from deploying.
On most installations `giantswarm` is the only organization deployed, and is deployed by grafana app.

I don't know how the org was deleted, I suspect it can happen when updating grafana app.
And I've seen test clusters where grafana was broken because of this.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
