### PR TITLE
support-multiple-tenants-in-one-org

### DIFF
--- a/api/v1alpha1/grafanaorganization_types.go
+++ b/api/v1alpha1/grafanaorganization_types.go
@@ -39,7 +39,7 @@ type GrafanaOrganizationSpec struct {
 	// Tenants is a list of tenants that are associated with the Grafana organization.
 	// +kubebuilder:example={"giantswarm"}
 	// +kube:validation:MinItems=1
-	Tenants []TenantID `json:"tenants,omitempty"`
+	Tenants []TenantID `json:"tenants"`
 }
 
 // TenantID is a unique identifier for a tenant. It must be lowercase.

--- a/api/v1alpha1/grafanaorganization_types.go
+++ b/api/v1alpha1/grafanaorganization_types.go
@@ -29,6 +29,8 @@ const (
 // GrafanaOrganizationSpec defines the desired state of GrafanaOrganization
 type GrafanaOrganizationSpec struct {
 	// DisplayName is the name displayed when viewing the organization in Grafana. It can be different from the actual org's name.
+	// +kubebuilder:example="Giant Swarm"
+	// +kubebuilder:validation:MinLength=1
 	DisplayName string `json:"displayName"`
 
 	// Access rules defines user permissions for interacting with the organization in Grafana.
@@ -36,6 +38,7 @@ type GrafanaOrganizationSpec struct {
 
 	// Tenants is a list of tenants that are associated with the Grafana organization.
 	// +kubebuilder:example={"giantswarm"}
+	// +kube:validation:MinItems=1
 	Tenants []TenantID `json:"tenants,omitempty"`
 }
 

--- a/config/crd/observability.giantswarm.io_grafanaorganizations.yaml
+++ b/config/crd/observability.giantswarm.io_grafanaorganizations.yaml
@@ -94,6 +94,7 @@ spec:
             required:
             - displayName
             - rbac
+            - tenants
             type: object
           status:
             description: GrafanaOrganizationStatus defines the observed state of GrafanaOrganization

--- a/config/crd/observability.giantswarm.io_grafanaorganizations.yaml
+++ b/config/crd/observability.giantswarm.io_grafanaorganizations.yaml
@@ -50,6 +50,8 @@ spec:
               displayName:
                 description: DisplayName is the name displayed when viewing the organization
                   in Grafana. It can be different from the actual org's name.
+                example: Giant Swarm
+                minLength: 1
                 type: string
               rbac:
                 description: Access rules defines user permissions for interacting

--- a/internal/controller/predicates/predicates_test.go
+++ b/internal/controller/predicates/predicates_test.go
@@ -1,0 +1,210 @@
+package predicates
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+func TestIsGrafanaPod(t *testing.T) {
+	tests := []struct {
+		name     string
+		pod      *corev1.Pod
+		expected bool
+	}{
+		{
+			name:     "nil pod",
+			pod:      nil,
+			expected: false,
+		},
+		{
+			name: "non-Grafana pod",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "non-grafana-pod",
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Grafana pod with correct labels",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-pod",
+					Namespace: "monitoring",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": "grafana",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Grafana pod with incorrect namespace",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-pod",
+					Namespace: "default",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": "grafana",
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Grafana pod with incorrect label",
+			pod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-pod",
+					Namespace: "monitoring",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": "not-grafana",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isGrafanaPod(tt.pod)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}
+
+func TestGrafanaPodRecreatedPredicate_Update(t *testing.T) {
+	tests := []struct {
+		name     string
+		oldPod   *corev1.Pod
+		newPod   *corev1.Pod
+		expected bool
+	}{
+		{
+			name:     "nil old object",
+			oldPod:   nil,
+			newPod:   &corev1.Pod{},
+			expected: false,
+		},
+		{
+			name:     "nil new object",
+			oldPod:   &corev1.Pod{},
+			newPod:   nil,
+			expected: false,
+		},
+		{
+			name: "non-Grafana pod",
+			oldPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "non-grafana-pod",
+					Namespace: "default",
+				},
+			},
+			newPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "non-grafana-pod",
+					Namespace: "default",
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "Grafana pod not ready to ready",
+			oldPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-pod",
+					Namespace: "monitoring",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": "grafana",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			newPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-pod",
+					Namespace: "monitoring",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": "grafana",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "Grafana pod ready to not ready",
+			oldPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-pod",
+					Namespace: "monitoring",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": "grafana",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionTrue,
+						},
+					},
+				},
+			},
+			newPod: &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "grafana-pod",
+					Namespace: "monitoring",
+					Labels: map[string]string{
+						"app.kubernetes.io/instance": "grafana",
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{
+						{
+							Type:   corev1.PodReady,
+							Status: corev1.ConditionFalse,
+						},
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+
+	predicate := GrafanaPodRecreatedPredicate{}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := event.UpdateEvent{
+				ObjectOld: tt.oldPod,
+				ObjectNew: tt.newPod,
+			}
+			result := predicate.Update(e)
+			if result != tt.expected {
+				t.Errorf("expected %v, got %v", tt.expected, result)
+			}
+		})
+	}
+}

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -18,9 +18,9 @@ const (
 )
 
 var SharedOrg = Organization{
-	ID:       1,
-	Name:     "Shared Org",
-	TenantID: "giantswarm",
+	ID:        1,
+	Name:      "Shared Org",
+	TenantIDs: []string{"giantswarm"},
 }
 
 // We need to use a custom name for now until we can replace the existing datasources.

--- a/pkg/grafana/types.go
+++ b/pkg/grafana/types.go
@@ -1,9 +1,11 @@
 package grafana
 
+import "strings"
+
 type Organization struct {
-	ID       int64
-	Name     string
-	TenantID string
+	ID        int64
+	Name      string
+	TenantIDs []string
 }
 
 type Datasource struct {
@@ -33,12 +35,12 @@ func (d Datasource) buildJSONData() map[string]interface{} {
 }
 
 func (d Datasource) buildSecureJSONData(organization Organization) map[string]string {
-	tenant := organization.TenantID
+	tenantIDs := organization.TenantIDs
 	if d.Type != "loki" {
 		// We do not support multi-tenancy for Mimir yet
-		tenant = "anonymous"
+		tenantIDs = []string{"anonymous"}
 	}
 	return map[string]string{
-		"httpHeaderValue1": tenant,
+		"httpHeaderValue1": strings.Join(tenantIDs, "|"),
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it

This PR adds support for multiple tenant in the grafana organization CRs to support multiple organizations on the read path for plaform teams and so on https://github.com/giantswarm/roadmap/issues/3784


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
