### PR TITLE
fix organization order when requeuing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix grafana organization reordering.
+
 ## [0.10.0] - 2024-12-10
 
 ### Added

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -17,10 +17,10 @@ limitations under the License.
 package controller
 
 import (
+	"cmp"
 	"context"
 	"fmt"
 	"slices"
-	"strings"
 
 	grafanaAPI "github.com/grafana/grafana-openapi-client-go/client"
 	"github.com/pkg/errors"
@@ -138,6 +138,10 @@ func (r *GrafanaOrganizationReconciler) SetupWithManager(mgr ctrl.Manager) error
 					return []reconcile.Request{}
 				}
 
+				// Sort organizations by orgID to ensure the order is deterministic.
+				// This is important to prevent incorrect ordering of organizations on grafana restarts.
+				slices.SortStableFunc(organizations.Items, sortOrganizationsByID)
+
 				// Reconcile all grafana organizations when the grafana pod is recreated
 				requests := make([]reconcile.Request, 0, len(organizations.Items))
 				for _, organization := range organizations.Items {
@@ -152,6 +156,19 @@ func (r *GrafanaOrganizationReconciler) SetupWithManager(mgr ctrl.Manager) error
 			builder.WithPredicates(predicates.GrafanaPodRecreatedPredicate{}),
 		).
 		Complete(r)
+}
+
+func sortOrganizationsByID(i, j v1alpha1.GrafanaOrganization) int {
+	// if both orgs have a nil orgID, they are equal
+	// if one org has a nil orgID, it is higher than the other as it was not created in Grafana yet
+	if i.Status.OrgID == 0 && j.Status.OrgID == 0 {
+		return 0
+	} else if i.Status.OrgID == 0 {
+		return 1
+	} else if j.Status.OrgID == 0 {
+		return -1
+	}
+	return cmp.Compare(i.Status.OrgID, j.Status.OrgID)
 }
 
 // reconcileCreate creates the grafanaOrganization.
@@ -368,14 +385,11 @@ func (r *GrafanaOrganizationReconciler) configureGrafana(ctx context.Context) er
 	}
 
 	_, err = controllerutil.CreateOrPatch(ctx, r.Client, grafanaConfig, func() error {
-		organizations := organizationList.Items
 		// We always sort the organizations to ensure the order is deterministic and the configmap is stable
 		// in order to prevent grafana to restarts.
-		slices.SortFunc(organizations, func(i, j v1alpha1.GrafanaOrganization) int {
-			return strings.Compare(i.Name, j.Name)
-		})
+		slices.SortStableFunc(organizationList.Items, sortOrganizationsByID)
 
-		config, err := templating.GenerateGrafanaConfiguration(organizations)
+		config, err := templating.GenerateGrafanaConfiguration(organizationList.Items)
 		if err != nil {
 			logger.Error(err, "failed to generate grafana user configmap values.")
 			return errors.WithStack(err)
@@ -383,7 +397,7 @@ func (r *GrafanaOrganizationReconciler) configureGrafana(ctx context.Context) er
 
 		// TODO: to be removed for next release
 		// cleanup owner references from the config map, see https://github.com/giantswarm/observability-operator/pull/183
-		for _, organization := range organizations {
+		for _, organization := range organizationList.Items {
 			// nolint:errcheck,gosec // ignore errors, owner references are probably already gone
 			controllerutil.RemoveOwnerReference(&organization, grafanaConfig, r.Scheme)
 		}


### PR DESCRIPTION
### What this PR does / why we need it

This PR ensures we requeue organizations in the correct order to avoid having multiple organizations with the same org-id

What I think happens is that we create some organizations and they are created in grafana like so:

giantswarm with orgId 2
testorg with orgId 3

This restarts grafana of course so the organizations are enqueued and reconciled one by one.

The issue here is that this order is undeterministic as it rely on the controller-runtime cache that can return things in whatever order.
The best solution imo is to make sure we enqueue organizations in the proper order of their status orgID.

Another possible solution is to remove the org id from all orgs status when we know we restart grafana but that looks a it too cumbersome.

The only downside I see to this is that we will have to fix existing issues manually but this should only be the case on glean and golem so I think we should be fine.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
