### PR TITLE
improved run-local port-forward management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- improved run-local port-forward management
+
 ### Removed
 
 - Remove turtle related Alertmanager configuration


### PR DESCRIPTION
### What this PR does / why we need it

run-local.sh improvements:
- when heavily used, kubectl port-forwards use to crash. So I put them in an infinite loop so they are re-created if they crash. This required some more complex logic to kill them at stop time.
- prometheus URL was incomplete, so I also fixed it.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
