### PR TITLE
fixed loading dashboard with an id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - improved run-local port-forward management
 
+### Fixed
+
+- fixed loading dashboards when they have an `id` defined
+
 ### Removed
 
 - Remove turtle related Alertmanager configuration

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -174,6 +174,12 @@ func getDashboardUID(dashboard map[string]interface{}) (string, error) {
 	return UID, nil
 }
 
+func cleanDashboardID(dashboard map[string]interface{}) {
+	if dashboard["id"] != nil {
+		delete(dashboard, "id")
+	}
+}
+
 func getOrgFromDashboardConfigmap(dashboard *v1.ConfigMap) (string, error) {
 	// Try to look for an annotation first
 	annotations := dashboard.GetAnnotations()
@@ -231,6 +237,9 @@ func (r DashboardReconciler) configureDashboard(ctx context.Context, dashboardCM
 			logger.Error(err, "Skipping dashboard, no UID found")
 			continue
 		}
+
+		// Clean the dashboard ID to avoid conflicts
+		cleanDashboardID(dashboard)
 
 		// Create or update dashboard
 		err = grafana.PublishDashboard(r.GrafanaAPI, dashboard)
@@ -291,6 +300,9 @@ func (r DashboardReconciler) reconcileDelete(ctx context.Context, dashboardCM *v
 			logger.Error(err, "Skipping dashboard, no UID found")
 			continue
 		}
+
+		// Clean the dashboard ID to avoid conflicts
+		cleanDashboardID(dashboard)
 
 		_, err = r.GrafanaAPI.Dashboards.GetDashboardByUID(dashboardUID)
 		if err != nil {


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/roadmap/issues/3696

Some dashboards could not be loaded because they have an `id` defined.
This was conflicting with previously-created dashboards.
So with this PR, the operator removes and ignores the ID, and lets grafana internally assign a random one.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
