### PR TITLE
Create per controller Grafana clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Create a different Grafana client per controller to avoid race conditions
+
 ## [0.13.2] - 2025-02-06
 
 ### Added

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -44,7 +44,7 @@ const (
 )
 
 func SetupDashboardReconciler(mgr manager.Manager, conf config.Config) error {
-	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, conf)
+	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, conf, "dashboard-controller")
 	if err != nil {
 		return fmt.Errorf("unable to create grafana client: %w", err)
 	}

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -36,7 +36,7 @@ type GrafanaOrganizationReconciler struct {
 }
 
 func SetupGrafanaOrganizationReconciler(mgr manager.Manager, conf config.Config) error {
-	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, conf)
+	grafanaAPI, err := grafanaclient.GenerateGrafanaClient(conf.GrafanaURL, conf, "organization-controller")
 	if err != nil {
 		return fmt.Errorf("unable to create grafana client: %w", err)
 	}

--- a/pkg/grafana/client/client.go
+++ b/pkg/grafana/client/client.go
@@ -79,6 +79,9 @@ func GenerateGrafanaClient(grafanaURL *url.URL, conf config.Config, userLogin st
 		_, err = adminClient.AdminUsers.AdminUpdateUserPassword(user.Payload.ID, &models.AdminUpdateUserPasswordForm{
 			Password: models.Password(userPassword),
 		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to update password for user %q: %w", userLogin, err)
+		}
 	}
 
 	// Create grafana client with new credentials

--- a/pkg/grafana/client/client.go
+++ b/pkg/grafana/client/client.go
@@ -1,11 +1,16 @@
 package client
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
+	"sync"
 
 	grafana "github.com/grafana/grafana-openapi-client-go/client"
+	"github.com/grafana/grafana-openapi-client-go/client/users"
+	"github.com/grafana/grafana-openapi-client-go/models"
 
+	"github.com/giantswarm/observability-operator/pkg/common/password"
 	"github.com/giantswarm/observability-operator/pkg/config"
 )
 
@@ -13,28 +18,100 @@ const (
 	clientConfigNumRetries = 3
 )
 
-func GenerateGrafanaClient(grafanaURL *url.URL, conf config.Config) (*grafana.GrafanaHTTPAPI, error) {
+var (
+	// clients keep track of the user logins that have already been used to create a client.
+	clients      = make(map[string]bool)
+	clientsMutex sync.Mutex
+)
+
+// GenerateGrafanaClient creates a new Grafana client for the given userLogin.
+// Only a single client per login can be created to avoid concurency issues.
+func GenerateGrafanaClient(grafanaURL *url.URL, conf config.Config, userLogin string) (*grafana.GrafanaHTTPAPI, error) {
+	clientsMutex.Lock()
+	defer clientsMutex.Unlock()
+
+	if _, ok := clients[userLogin]; ok {
+		return nil, fmt.Errorf("client already created for user %q. Only a single client per login is created to avoid concurency issues.", userLogin)
+	}
+
+	grafanaTLSConfig := TLSConfig{
+		Cert: conf.Environment.GrafanaTLSCertFile,
+		Key:  conf.Environment.GrafanaTLSKeyFile,
+	}
+
+	// Create the "root" admin client
+	adminCredentials := AdminCredentials{
+		Username: conf.Environment.GrafanaAdminUsername,
+		Password: conf.Environment.GrafanaAdminPassword,
+	}
+
+	adminClient, err := generateGrafanaClient(grafanaURL, adminCredentials, grafanaTLSConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create grafana client: %w", err)
+	}
+
+	// Generate a password for the requested login
+	passwordManager := password.SimpleManager{}
+	userPassword, err := passwordManager.GeneratePassword(32)
+	if err != nil {
+		return nil, fmt.Errorf("unable to generate password: %w", err)
+	}
+
+	// Check if user exists
+	user, err := adminClient.Users.GetUserByLoginOrEmail(userLogin)
+	if err != nil {
+		var loginOrEmailNotFoundErr *users.GetUserByLoginOrEmailNotFound
+		if errors.As(err, loginOrEmailNotFoundErr) {
+			return nil, fmt.Errorf("unable to get user %q: %w", userLogin, err)
+		}
+
+		// Create user
+		_, err = adminClient.AdminUsers.AdminCreateUser(&models.AdminCreateUserForm{
+			Login:    userLogin,
+			Email:    fmt.Sprintf("%s@observability-operator", userLogin),
+			Password: models.Password(userPassword),
+		})
+		if err != nil {
+			return nil, fmt.Errorf("unable to create user %q: %w", userLogin, err)
+		}
+	} else {
+		// Update password if user exists
+		_, err = adminClient.AdminUsers.AdminUpdateUserPassword(user.Payload.ID, &models.AdminUpdateUserPasswordForm{
+			Password: models.Password(userPassword),
+		})
+	}
+
+	// Create grafana client with new credentials
+	userCredentials := AdminCredentials{
+		Username: userLogin,
+		Password: userPassword,
+	}
+	client, err := generateGrafanaClient(grafanaURL, userCredentials, grafanaTLSConfig)
+	if err != nil {
+		return nil, fmt.Errorf("unable to create grafana client for user %q: %w", userLogin, err)
+	}
+
+	// Mark the user login as used
+	clients[userLogin] = true
+
+	return client, nil
+}
+
+func generateGrafanaClient(grafanaURL *url.URL, credentials AdminCredentials, tlsConfig TLSConfig) (*grafana.GrafanaHTTPAPI, error) {
 	var err error
 
 	// Generate Grafana client
 	// Get grafana admin-password and admin-user
-	adminUserCredentials := AdminCredentials{
-		Username: conf.Environment.GrafanaAdminUsername,
-		Password: conf.Environment.GrafanaAdminPassword,
-	}
-	if adminUserCredentials.Username == "" {
-		return nil, fmt.Errorf("GrafanaAdminUsername not set: %q", conf.Environment.GrafanaAdminUsername)
+	if credentials.Username == "" {
+		return nil, fmt.Errorf("GrafanaAdminUsername not set")
 
 	}
-	if adminUserCredentials.Password == "" {
-		return nil, fmt.Errorf("GrafanaAdminPassword not set: %q", conf.Environment.GrafanaAdminPassword)
+	if credentials.Password == "" {
+		return nil, fmt.Errorf("GrafanaAdminPassword not set")
 
 	}
 
-	grafanaTLSConfig, err := TLSConfig{
-		Cert: conf.Environment.GrafanaTLSCertFile,
-		Key:  conf.Environment.GrafanaTLSKeyFile,
-	}.toTLSConfig()
+	grafanaTLSConfig, err := tlsConfig.toTLSConfig()
 	if err != nil {
 		return nil, fmt.Errorf("failed to build tls config: %w", err)
 	}
@@ -44,7 +121,7 @@ func GenerateGrafanaClient(grafanaURL *url.URL, conf config.Config) (*grafana.Gr
 		BasePath: "/api",
 		Host:     grafanaURL.Host,
 		// We use basic auth to authenticate on grafana.
-		BasicAuth: url.UserPassword(adminUserCredentials.Username, adminUserCredentials.Password),
+		BasicAuth: url.UserPassword(credentials.Username, credentials.Password),
 		// NumRetries contains the optional number of attempted retries.
 		NumRetries: clientConfigNumRetries,
 		TLSConfig:  grafanaTLSConfig,

--- a/pkg/grafana/client/client.go
+++ b/pkg/grafana/client/client.go
@@ -61,7 +61,7 @@ func GenerateGrafanaClient(grafanaURL *url.URL, conf config.Config, userLogin st
 	user, err := adminClient.Users.GetUserByLoginOrEmail(userLogin)
 	if err != nil {
 		var loginOrEmailNotFoundErr *users.GetUserByLoginOrEmailNotFound
-		if errors.As(err, loginOrEmailNotFoundErr) {
+		if errors.As(err, &loginOrEmailNotFoundErr) {
 			return nil, fmt.Errorf("unable to get user %q: %w", userLogin, err)
 		}
 


### PR DESCRIPTION
The operator currently throws many error related to not found resources.

I assume this is related to concurrent usage of the same user, since the [user context switch](https://grafana.com/docs/grafana/latest/developers/http_api/user/#switch-user-context-for-a-specified-user) seems to happen server side and not client side.

This PR proposes a solution to solve this problem by creating a different Grafana admin user and client for each controller. 

We can't use service accounts as they are scoped to an organization.