### PR TITLE
Do not trigger organization reconciliation on grafana pod deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update Grafana pod predicate to not trigger on pod deletion
+- Ensure organization is created before proceeding with datasources and sso settings
+
 ## [0.13.2] - 2025-02-06
 
 ### Added

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -160,17 +160,17 @@ func (r GrafanaOrganizationReconciler) reconcileCreate(ctx context.Context, graf
 		return ctrl.Result{}, nil
 	}
 
-	var lastError error
-
 	// Configure the shared organization in Grafana
 	if err := r.configureSharedOrg(ctx); err != nil {
-		lastError = err
+		return ctrl.Result{}, errors.WithStack(err)
 	}
 
 	// Configure the organization in Grafana
 	if err := r.configureOrganization(ctx, grafanaOrganization); err != nil {
-		lastError = err
+		return ctrl.Result{}, errors.WithStack(err)
 	}
+
+	var lastError error
 
 	// Update the datasources in the CR's status
 	if err := r.configureDatasources(ctx, grafanaOrganization); err != nil {

--- a/internal/controller/predicates/alertmanager_predicates.go
+++ b/internal/controller/predicates/alertmanager_predicates.go
@@ -20,6 +20,10 @@ func NewAlertmanagerSecretPredicate(conf config.Config) predicate.Predicate {
 			return false
 		}
 
+		if secret == nil {
+			return false
+		}
+
 		if !secret.DeletionTimestamp.IsZero() {
 			return false
 		}

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -34,6 +34,10 @@ func (GrafanaPodRecreatedPredicate) Update(e event.UpdateEvent) bool {
 		return false
 	}
 
+	if newPod == nil {
+		return false
+	}
+
 	if !newPod.DeletionTimestamp.IsZero() {
 		return false
 	}

--- a/internal/controller/predicates/predicates.go
+++ b/internal/controller/predicates/predicates.go
@@ -8,7 +8,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
 
-// GrafanaPodRecreatedPredicate implements an eevent handler predicate function.
+// GrafanaPodRecreatedPredicate implements an event handler predicate function.
 // This predicate is used to trigger a reconciliation when the Grafana pod is recreated to ensure the Grafana instance is up to date.
 type GrafanaPodRecreatedPredicate struct {
 	predicate.Funcs
@@ -33,6 +33,11 @@ func (GrafanaPodRecreatedPredicate) Update(e event.UpdateEvent) bool {
 	if !ok {
 		return false
 	}
+
+	if !newPod.DeletionTimestamp.IsZero() {
+		return false
+	}
+
 	return isGrafanaPod(newPod) && isPodReady(newPod)
 }
 


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32447

This PR fixes 2 things:

- Avoid triggering grafana organization reconciliation when the grafana pod is being deleted
- Ensure that the organization is present before proceeding with datasources and sso settings reconciliation