### PR TITLE
Fix organization context race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Fix race condition when switching organization in Grafana client by using WithOrgID method
+
 ## [0.13.2] - 2025-02-06
 
 ### Added

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -141,9 +141,11 @@ func ConfigureDefaultDatasources(ctx context.Context, grafanaAPI *client.Grafana
 
 	// TODO using a serviceaccount later would be better as they are scoped to an organization
 
-	grafanaAPIWithOrgID := grafanaAPI.WithOrgID(organization.ID)
+	currentOrgID := grafanaAPI.OrgID()
+	grafanaAPI.WithOrgID(organization.ID)
+	defer grafanaAPI.WithOrgID(currentOrgID)
 
-	configuredDatasourcesInGrafana, err := listDatasourcesForOrganization(ctx, grafanaAPIWithOrgID)
+	configuredDatasourcesInGrafana, err := listDatasourcesForOrganization(ctx, grafanaAPI)
 	if err != nil {
 		logger.Error(err, "failed to list datasources")
 		return nil, errors.WithStack(err)
@@ -171,7 +173,7 @@ func ConfigureDefaultDatasources(ctx context.Context, grafanaAPI *client.Grafana
 
 	for index, datasource := range datasourcesToCreate {
 		logger.Info("creating datasource", "datasource", datasource.Name)
-		created, err := grafanaAPIWithOrgID.Datasources.AddDataSource(
+		created, err := grafanaAPI.Datasources.AddDataSource(
 			&models.AddDataSourceCommand{
 				UID:            datasource.UID,
 				Name:           datasource.Name,
@@ -192,7 +194,7 @@ func ConfigureDefaultDatasources(ctx context.Context, grafanaAPI *client.Grafana
 
 	for _, datasource := range datasourcesToUpdate {
 		logger.Info("updating datasource", "datasource", datasource.Name)
-		_, err := grafanaAPIWithOrgID.Datasources.UpdateDataSourceByID(
+		_, err := grafanaAPI.Datasources.UpdateDataSourceByID(
 			strconv.FormatInt(datasource.ID, 10),
 			&models.UpdateDataSourceCommand{
 				UID:            datasource.UID,


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32447

This PR fixes an issue which causes race condition when using the `UserSetUsingOrg` with multiple client instances using same credentials and running in separate goroutines.
This method change the organization context for a user on the server-side, meaning that this would be changed for all client instances using the same credentials.

This PR proposes a solution to use the `WithOrgID` option to set the organization context for a specific client instance. This method changes the organization context client-side in the client instance.

### Before

Here is an example when using the `UserSetUsingOrg` (`/api/user/using/:orgId`) method to change the organization context for a user:

```bash
$ ./request-grafana.sh /api/org -s | jq -r . # Get current organization for signed-in-user
{
  "id": 1,
  "name": "Shared Org",
  "address": {
    "address1": "",
    "address2": "",
    "city": "",
    "zipCode": "",
    "state": "",
    "country": ""
  }
}
$ ./request-grafana.sh /api/datasources -s | jq -r . # Get datasource for current organization
[
  {
    "id": 4,
    "uid": "gs-loki",
    "orgId": 1,
    "name": "Loki",
    "type": "loki",
    "typeName": "Loki",
    "typeLogoUrl": "public/app/plugins/datasource/loki/img/loki_icon.svg",
    "access": "proxy",
    "url": "http://loki-gateway.loki.svc",
    "user": "",
    "database": "",
    "basicAuth": false,
    "isDefault": false,
    "jsonData": {
      "httpHeaderName1": "X-Scope-OrgID"
    },
    "readOnly": false
  },
  ... truncated ...
$ ./request-grafana.sh /api/user/using/2 -sXPOST | jq -r . # Change organization context for signed-in-user
{
  "message": "Active organization changed"
}
$ ./request-grafana.sh /api/org -s | jq -r . # Get current organization for signed-in-user
{
  "id": 2,
  "name": "Giant Swarm",
  "address": {
    "address1": "",
    "address2": "",
    "city": "",
    "zipCode": "",
    "state": "",
    "country": ""
  }
}
$ ./request-grafana.sh /api/datasources -s | jq -r . # Get datasource for current organization
[
  {
    "id": 7,
    "uid": "gs-loki",
    "orgId": 2,
    "name": "Loki",
    "type": "loki",
    "typeName": "Loki",
    "typeLogoUrl": "public/app/plugins/datasource/loki/img/loki_icon.svg",
    "access": "proxy",
    "url": "http://loki-gateway.loki.svc",
    "user": "",
    "database": "",
    "basicAuth": false,
    "isDefault": false,
    "jsonData": {
      "httpHeaderName1": "X-Scope-OrgID"
    },
    "readOnly": false
  },
  ... truncated ...
```

### After

```
 $ ./request-grafana.sh /api/datasources -s -H 'X-Grafana-Org-Id: 1' | jq -r .
[
  {
    "id": 4,
    "uid": "gs-loki",
    "orgId": 1,
    "name": "Loki",
    "type": "loki",
    "typeName": "Loki",
    "typeLogoUrl": "public/app/plugins/datasource/loki/img/loki_icon.svg",
    "access": "proxy",
    "url": "http://loki-gateway.loki.svc",
    "user": "",
    "database": "",
    "basicAuth": false,
    "isDefault": false,
    "jsonData": {
      "httpHeaderName1": "X-Scope-OrgID"
    },
    "readOnly": false
  },
    ... truncated ...
$ ./request-grafana.sh /api/datasources -s -H 'X-Grafana-Org-Id: 2' | jq -r .
[
  {
    "id": 7,
    "uid": "gs-loki",
    "orgId": 2,
    "name": "Loki",
    "type": "loki",
    "typeName": "Loki",
    "typeLogoUrl": "public/app/plugins/datasource/loki/img/loki_icon.svg",
    "access": "proxy",
    "url": "http://loki-gateway.loki.svc",
    "user": "",
    "database": "",
    "basicAuth": false,
    "isDefault": false,
    "jsonData": {
      "httpHeaderName1": "X-Scope-OrgID"
    },
    "readOnly": false
  },
    ... truncated ...
```
