### PR TITLE
configure alloy sample age limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Configure Alloy-metrics `sample_age_config` so that alloy does not indefinitely retry to send old and rejected samples.
+
 ## [0.13.3] - 2025-02-10
 
 ### Changed

--- a/pkg/common/monitoring/monitoring.go
+++ b/pkg/common/monitoring/monitoring.go
@@ -37,6 +37,7 @@ const (
 	QueueConfigCapacity          = 30000
 	QueueConfigMaxSamplesPerSend = 150000
 	QueueConfigMaxShards         = 10
+	QueueConfigSampleAgeLimit    = "30m"
 
 	RemoteWriteName                = "mimir"
 	RemoteWriteEndpointTemplateURL = "https://mimir.%s/api/v1/push"

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -125,6 +125,7 @@ func (a *Service) generateAlloyConfig(ctx context.Context, cluster *clusterv1.Cl
 		QueueConfigCapacity          int
 		QueueConfigMaxSamplesPerSend int
 		QueueConfigMaxShards         int
+		QueueConfigSampleAgeLimit    string
 
 		WALTruncateFrequency string
 
@@ -140,6 +141,7 @@ func (a *Service) generateAlloyConfig(ctx context.Context, cluster *clusterv1.Cl
 		QueueConfigCapacity:          commonmonitoring.QueueConfigCapacity,
 		QueueConfigMaxSamplesPerSend: commonmonitoring.QueueConfigMaxSamplesPerSend,
 		QueueConfigMaxShards:         commonmonitoring.QueueConfigMaxShards,
+		QueueConfigSampleAgeLimit:    commonmonitoring.QueueConfigSampleAgeLimit,
 
 		WALTruncateFrequency: a.MonitoringConfig.WALTruncateFrequency.String(),
 

--- a/pkg/monitoring/alloy/templates/alloy-config.alloy.template
+++ b/pkg/monitoring/alloy/templates/alloy-config.alloy.template
@@ -2,7 +2,7 @@ prometheus.operator.servicemonitors "default" {
   forward_to = [prometheus.remote_write.default.receiver]
   selector {
     match_expression {
-      key = "application.giantswarm.io/team"
+      key      = "application.giantswarm.io/team"
       operator = "Exists"
     }
   }
@@ -18,7 +18,7 @@ prometheus.operator.podmonitors "default" {
   forward_to = [prometheus.remote_write.default.receiver]
   selector {
     match_expression {
-      key = "application.giantswarm.io/team"
+      key      = "application.giantswarm.io/team"
       operator = "Exists"
     }
   }
@@ -32,9 +32,9 @@ prometheus.operator.podmonitors "default" {
 
 prometheus.remote_write "default" {
   endpoint {
-    url = env("{{ .RemoteWriteURLEnvVarName }}")
-    name = env("{{ .RemoteWriteNameEnvVarName }}")
-    enable_http2 = false
+    url            = env("{{ .RemoteWriteURLEnvVarName }}")
+    name           = env("{{ .RemoteWriteNameEnvVarName }}")
+    enable_http2   = false
     remote_timeout = "{{ .RemoteWriteTimeout }}"
     basic_auth {
       username = env("{{ .RemoteWriteBasicAuthUsernameEnvVarName }}")
@@ -44,9 +44,10 @@ prometheus.remote_write "default" {
       insecure_skip_verify = {{ .RemoteWriteTLSInsecureSkipVerify }}
     }
     queue_config {
-      capacity = {{ .QueueConfigCapacity }}
+      capacity             = {{ .QueueConfigCapacity }}
+      max_shards           = {{ .QueueConfigMaxShards }}
       max_samples_per_send = {{ .QueueConfigMaxSamplesPerSend }}
-      max_shards = {{ .QueueConfigMaxShards }}
+      sample_age_limit     = {{ .QueueConfigSampleAgeLimit }}
     }
   }
   wal {


### PR DESCRIPTION
### What this PR does / why we need it

Fixes https://github.com/giantswarm/roadmap/issues/3856

This PR sets the sample_age_limit because alloy by default tries to send samples that have been rejected even after 1 day of rejection which triggers the alert on our hand. 
Configuring the sample_age_limit to 30m will ensure alloy drops those rejected entries.
For more context, see https://github.com/giantswarm/roadmap/issues/3856#issuecomment-2647504422

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
