### PR TITLE
use the new alert annotations for runbook and dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- update the notification template to take into account the new alert annotations
+  - `opsrecipe` => `runbook_url`
+  - `dashboard` => `dashboardUid`
+
 ## [0.15.0] - 2025-02-10
 
 ### Removed

--- a/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
+++ b/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
@@ -189,18 +189,18 @@ receivers:
     send_resolved: true
     actions: &slack-actions
     - type: button
-      text: ':green_book: OpsRecipe'
-      url: '{{`{{ template "__runbookurl" . }}`}}'
+      text: ':green_book: Runbook'
+      url: '{{`{{ template "__runbook_url" . }}`}}'
       style: '{{`{{ if eq .Status "firing" }}primary{{ else }}default{{ end }}`}}'
     - type: button
       text: ':coffin: Linked PMs'
       url: '{{`{{ template "__alert_linked_postmortems" . }}`}}'
     - type: button
       text: ':mag: Query'
-      url: '{{`{{ template "__alerturl" . }}`}}'
+      url: '{{`{{ template "__alert_url" . }}`}}'
     - type: button
       text: ':grafana: Dashboard'
-      url: '{{`{{ template "__dashboardurl" . }}`}}'
+      url: '{{`{{ template "__dashboard_url" . }}`}}'
     - type: button
       text: ':no_bell: Silence'
       url: '{{`{{ template "__alert_silence_link" .}}`}}'

--- a/helm/observability-operator/files/alertmanager/notification-template.tmpl
+++ b/helm/observability-operator/files/alertmanager/notification-template.tmpl
@@ -4,7 +4,7 @@
 {{ define "slack.default.username" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "slack.default.fallback" }}{{ template "slack.default.title" . }} | {{ template "slack.default.titlelink" . }}{{ end }}
 {{ define "slack.default.pretext" }}{{ end }}
-{{ define "slack.default.titlelink" }}{{ template "__alerturl" . }}{{ end }}
+{{ define "slack.default.titlelink" }}{{ template "__alert_url" . }}{{ end }}
 {{ define "slack.default.iconemoji" }}{{ end }}
 {{ define "slack.default.iconurl" }}{{ end }}
 {{ define "slack.default.text" }}*Cluster:* {{ (index .Alerts 0).Labels.installation }}{{ if (index .Alerts 0).Labels.cluster_id }} / {{ (index .Alerts 0).Labels.cluster_id }}{{ end }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }}
@@ -24,17 +24,17 @@
 {{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }} / {{ .GroupLabels.cluster_id }}{{ if (index .Alerts 0).Labels.service }} / {{ (index .Alerts 0).Labels.service }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" -}}
-{{ if (index .Alerts 0).Annotations.opsrecipe -}}
-📗 Runbook: {{ template "__runbookurl" . }}
+{{ if (index .Alerts 0).Annotations.runbook_url -}}
+📗 Runbook: {{ template "__runbook_url" . }}
 {{ else -}}
 📗 Runbook: ⚠️ There is no **runbook** for this alert, time to get your pen.
 {{- end }}
-{{ if (index .Alerts 0).Annotations.dashboard -}}
-📈 Dashboard: {{ template "__dashboardurl" . }}
+{{ if (index .Alerts 0).Annotations.dashboardUid -}}
+📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
 📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
 {{ end -}}
-👀 Explore: {{ template "__alerturl" . }}
+👀 Explore: {{ template "__alert_url" . }}
 🔔 Silence: {{ template "__alert_silence_link" . }}
 
 ---

--- a/helm/observability-operator/files/alertmanager/url-template.tmpl.helm-template
+++ b/helm/observability-operator/files/alertmanager/url-template.tmpl.helm-template
@@ -1,21 +1,21 @@
 {{`
 {{/*
-  __alerturl is the link pointing to a page in Grafana with details and source expressiong of the alert.
+  __alert_url is the link pointing to a page in Grafana with details and source expressiong of the alert.
 */}}
-{{ define "__alerturl" }}`}}{{ .Values.alerting.grafanaAddress }}{{`/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}`}}{{ .Values.alerting.grafanaAddress }}{{`/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{/*
-  __dashboardurl is the link pointing the Grafana dashboard referenced in the alert annotation if any.
+  __dashboard_url is the link pointing the Grafana dashboard referenced in the alert annotation if any.
 */}}
-{{ define "__dashboardurl" -}}
-{{- if match "^https://.+" (index .Alerts 0).Annotations.dashboard }}{{ (index .Alerts 0).Annotations.dashboard -}}
+{{ define "__dashboard_url" -}}
+{{- if match "^https://.+" (index .Alerts 0).Annotations.dashboardUid }}{{ (index .Alerts 0).Annotations.dashboardUid -}}
 {{- else -}}
-`}}{{ .Values.alerting.grafanaAddress }}{{`/d/{{ (index .Alerts 0).Annotations.dashboard -}}
+`}}{{ .Values.alerting.grafanaAddress }}{{`/d/{{ (index .Alerts 0).Annotations.dashboardUid -}}
 {{- end -}}
 {{- end }}
 
 {{/*
-  __runbookurl is a link to the intranet's opsrecipe referenced in the alert annotation.
+  __runbook_url is a link to the intranet's runbook referenced in the alert annotation.
 */}}
-{{ define "__runbookurl" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.opsrecipe }}{{- end }}
+{{ define "__runbook_url" -}}https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/{{ (index .Alerts 0).Annotations.runbook_url }}{{- end }}
 `}}


### PR DESCRIPTION
### What this PR does / why we need it

This pull request includes several changes to update the alert notification templates and related files to use new alert annotations added https://github.com/giantswarm/prometheus-rules/pull/1509 and https://github.com/giantswarm/sloth-rules/pull/280 as part of https://github.com/giantswarm/giantswarm/issues/28089

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
