### PR TITLE
Add Grafana url when there's no dashboard in the alert notification template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Use smaller dockerfile to reduce build time as ABS already generates the go binary.
+- Add Grafana url when there's no dashboard in the alert notification template.
 
 ## [0.17.0] - 2025-02-25
 

--- a/helm/observability-operator/files/alertmanager/notification-template.tmpl
+++ b/helm/observability-operator/files/alertmanager/notification-template.tmpl
@@ -35,7 +35,7 @@
 {{ if or ((index .Alerts 0).Annotations.__dashboardUid__) ((index .Alerts 0).Annotations.dashboardExternalUrl) -}}
 📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
-📈 Dashboard: {{ template "__grafana_url" }} (⚠️ There is no **dashboard** for this alert, time to sketch.)
+📈 Dashboard: {{ template "__grafana_url" . }} (⚠️ There is no **dashboard** for this alert, time to sketch.)
 {{ end -}}
 👀 Explore: {{ template "__alert_url" . }}
 🔔 Silence: {{ template "__alert_silence_link" . }}

--- a/helm/observability-operator/files/alertmanager/notification-template.tmpl
+++ b/helm/observability-operator/files/alertmanager/notification-template.tmpl
@@ -35,7 +35,7 @@
 {{ if or ((index .Alerts 0).Annotations.__dashboardUid__) ((index .Alerts 0).Annotations.dashboardExternalUrl) -}}
 📈 Dashboard: {{ template "__dashboard_url" . }}
 {{ else -}}
-📈 Dashboard: ⚠️ There is no **dashboard** for this alert, time to sketch.
+📈 Dashboard: {{ template "__grafana_url" }} (⚠️ There is no **dashboard** for this alert, time to sketch.)
 {{ end -}}
 👀 Explore: {{ template "__alert_url" . }}
 🔔 Silence: {{ template "__alert_silence_link" . }}

--- a/helm/observability-operator/files/alertmanager/url-template.tmpl.helm-template
+++ b/helm/observability-operator/files/alertmanager/url-template.tmpl.helm-template
@@ -12,8 +12,10 @@
 {{ define "__dashboard_url" -}}
 {{- if (index .Alerts 0).Annotations.dashboardExternalUrl }}
 {{- (index .Alerts 0).Annotations.dashboardExternalUrl -}}
-{{- else -}}
+{{- else if (index .Alerts 0).Annotations.__dashboardUid__ -}}
 {{ template "__grafana_url" }}/d/{{ (index .Alerts 0).Annotations.__dashboardUid__ }}?{{ (index .Alerts 0).Annotations.dashboardQueryParams -}}
+{{- else -}}
+{{ template "__grafana_url" }}
 {{- end -}}
 {{- end }}
 `}}

--- a/helm/observability-operator/files/alertmanager/url-template.tmpl.helm-template
+++ b/helm/observability-operator/files/alertmanager/url-template.tmpl.helm-template
@@ -1,8 +1,10 @@
 {{`
+{{ define "__grafana_url" }}`}}{{ .Values.alerting.grafanaAddress }}{{`{{ end }}
+
 {{/*
   __alert_url is the link pointing to a page in Grafana with details and source expressiong of the alert.
 */}}
-{{ define "__alert_url" }}`}}{{ .Values.alerting.grafanaAddress }}{{`/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
+{{ define "__alert_url" }}{{ template "__grafana_url" }}/alerting/Mimir/{{ .CommonLabels.alertname }}/find{{ end }}
 
 {{/*
   __dashboard_url is the link pointing the Grafana dashboard referenced in the alert annotation if any.
@@ -11,7 +13,7 @@
 {{- if (index .Alerts 0).Annotations.dashboardExternalUrl }}
 {{- (index .Alerts 0).Annotations.dashboardExternalUrl -}}
 {{- else -}}
-`}}{{ .Values.alerting.grafanaAddress }}{{`/d/{{ (index .Alerts 0).Annotations.__dashboardUid__ }}?{{ (index .Alerts 0).Annotations.dashboardQueryParams -}}
+{{ template "__grafana_url" }}/d/{{ (index .Alerts 0).Annotations.__dashboardUid__ }}?{{ (index .Alerts 0).Annotations.dashboardQueryParams -}}
 {{- end -}}
 {{- end }}
 `}}


### PR DESCRIPTION
This PR change the alert notification template to include the Grafana url when there's no dashboard available for the alert.