### PR TITLE
remove giantswarm from the list of read tenants fo fix the grafana rule pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix default read tenant to anonymous to ensure grafana rules pages work until the tenant switch is released.
+
 ## [0.18.0] - 2025-03-05
 
 ### Changed

--- a/pkg/common/monitoring/monitoring.go
+++ b/pkg/common/monitoring/monitoring.go
@@ -47,7 +47,7 @@ const (
 	DefaultWriteTenant = "anonymous"
 )
 
-var DefaultReadTenants = []string{"anonymous", "giantswarm"}
+var DefaultReadTenants = []string{"anonymous"}
 
 func GetServicePriority(cluster *clusterv1.Cluster) string {
 	if servicePriority, ok := cluster.GetLabels()[servicePriorityLabel]; ok && servicePriority != "" {


### PR DESCRIPTION
### What this PR does / why we need it

As it is unlikely that we switch the tenant today, we should at least make sure the grafana rule page works until we do

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
