### PR TITLE
Revert "Switch alerting from anonymous to giantswarm tenant (#282)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,16 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert tenant switch and clean up giantswarm tenant.
+
 ## [0.19.0] - 2025-03-06
 
 ### Added
 
 - Add cleanup for Mimir Alertmanager anonymous tenant's configuration.
 - Add cleanup for Mimir Ruler anonymous tenant's rules.
-
-### Fixed
-
-- Fix default read tenant to anonymous to ensure grafana rules pages work until the tenant switch is released.
 
 ## [0.18.0] - 2025-03-05
 
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Use smaller dockerfile to reduce build time as ABS already generates the go binary.
 - Read metrics from both anonymous and giantswarm tenant at once.
 - Refactor hardcoded tenant values to prepare the switch from the anonymous to the giantswarm tenant.
-- Switch the alerting component from the anonymous to the giantswarm tenant.
 - Add Grafana url when there's no dashboard in the alert notification template.
 
 ## [0.17.0] - 2025-02-25

--- a/pkg/alertmanager/alertmanager.go
+++ b/pkg/alertmanager/alertmanager.go
@@ -28,8 +28,6 @@ const (
 	templatesSuffix = ".tmpl"
 
 	alertmanagerAPIPath = "/api/v1/alerts"
-
-	rulerTenantDeletionUrl = "http://mimir-ruler.mimir.svc:8080/ruler/delete_tenant_config"
 )
 
 type Service struct {
@@ -83,21 +81,6 @@ func (s Service) Configure(ctx context.Context, secret *v1.Secret) error {
 	}
 
 	logger.Info("Alertmanager: configured")
-
-	// TODO Clean up the anonymous tenant alertmanager deletion code in the next release
-	logger.Info("Alertmanager: cleaning up anonymous tenant")
-
-	err = s.deleteTenantConfiguration(ctx, "anonymous")
-	if err != nil {
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to delete the alertmanager anonymous tenant configuration: %w", err))
-	}
-
-	err = s.deleteRules(ctx, "anonymous")
-	if err != nil {
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to delete rules for the anonymous tenant: %w", err))
-	}
-
-	logger.Info("Alertmanager: anonymous tenant cleaned up")
 	return nil
 }
 
@@ -157,85 +140,6 @@ func (s Service) configure(ctx context.Context, alertmanagerConfigContent []byte
 
 		return errors.WithStack(fmt.Errorf("alertmanager: failed to send configuration: %w", e))
 	}
-
-	return nil
-}
-
-// deleteTenantConfiguration deletes a tenant using the Mimir Alertmanager's API
-func (s Service) deleteTenantConfiguration(ctx context.Context, tenantID string) error {
-	logger := log.FromContext(ctx)
-
-	url := s.alertmanagerURL + alertmanagerAPIPath
-	logger.WithValues("url", url, "tenant", tenantID).Info("Alertmanager: deleting tenant")
-
-	// Send request to Alertmanager's API
-	req, err := http.NewRequest(http.MethodDelete, url, nil)
-	if err != nil {
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to create request: %w", err))
-	}
-
-	req.Header.Set(common.OrgIDHeader, tenantID)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to send request: %w", err))
-	}
-	defer resp.Body.Close() // nolint: errcheck
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return errors.WithStack(fmt.Errorf("alertmanager: failed to read response: %w", err))
-		}
-
-		e := APIError{
-			Code:    resp.StatusCode,
-			Message: string(respBody),
-		}
-
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to delete tenant configuration: %w", e))
-	}
-
-	logger.WithValues("status_code", resp.StatusCode).Info("Alertmanager: tenant configuration deleted")
-
-	return nil
-}
-
-// deleteRules deletes all rules for a tenant using the Mimir Alertmanager's API
-func (s Service) deleteRules(ctx context.Context, tenantID string) error {
-	logger := log.FromContext(ctx)
-
-	logger.WithValues("url", rulerTenantDeletionUrl, "tenant", tenantID).Info("Alertmanager: delete rules for tenant")
-
-	// Send request to Alertmanager's API
-	req, err := http.NewRequest(http.MethodPost, rulerTenantDeletionUrl, nil)
-	if err != nil {
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to create request: %w", err))
-	}
-
-	req.Header.Set(common.OrgIDHeader, tenantID)
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to send request: %w", err))
-	}
-	defer resp.Body.Close() // nolint: errcheck
-
-	if resp.StatusCode != http.StatusOK {
-		respBody, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return errors.WithStack(fmt.Errorf("alertmanager: failed to read response: %w", err))
-		}
-
-		e := APIError{
-			Code:    resp.StatusCode,
-			Message: string(respBody),
-		}
-
-		return errors.WithStack(fmt.Errorf("alertmanager: failed to delete rules for tenant: %w", e))
-	}
-
-	logger.WithValues("status_code", resp.StatusCode).Info("Alertmanager: deleted rules for tenant")
 
 	return nil
 }

--- a/pkg/common/monitoring/monitoring.go
+++ b/pkg/common/monitoring/monitoring.go
@@ -44,7 +44,7 @@ const (
 	RemoteWriteTimeout             = "60s"
 
 	OrgIDHeader        = "X-Scope-OrgID"
-	DefaultWriteTenant = "giantswarm"
+	DefaultWriteTenant = "anonymous"
 )
 
 var DefaultReadTenants = []string{"anonymous", "giantswarm"}

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -15,8 +15,9 @@ import (
 )
 
 const (
-	datasourceProxyAccessMode = "proxy"
-	mimirOldDatasourceUID     = "gs-mimir-old"
+	datasourceProxyAccessMode      = "proxy"
+	mimirAlertmanagerDatasourceUID = "gs-mimir-alertmanager"
+	mimirDatasourceUID             = "gs-mimir"
 )
 
 var orgNotFoundError = errors.New("organization not found")
@@ -30,7 +31,7 @@ var SharedOrg = Organization{
 var defaultDatasources = []Datasource{
 	{
 		Name:      "Mimir Alertmanager",
-		UID:       "gs-mimir-alertmanager",
+		UID:       mimirAlertmanagerDatasourceUID,
 		Type:      "alertmanager",
 		IsDefault: true,
 		URL:       "http://mimir-alertmanager.mimir.svc:8080",
@@ -41,22 +42,8 @@ var defaultDatasources = []Datasource{
 		},
 	},
 	{
-		Name:   "Mimir (old tenant data)",
-		UID:    mimirOldDatasourceUID,
-		Type:   "prometheus",
-		URL:    "http://mimir-gateway.mimir.svc/prometheus",
-		Access: datasourceProxyAccessMode,
-		JSONData: map[string]interface{}{
-			"cacheLevel":     "None",
-			"httpMethod":     "POST",
-			"mimirVersion":   "2.14.0",
-			"prometheusType": "Mimir",
-			"timeInterval":   "60s",
-		},
-	},
-	{
 		Name:      "Mimir",
-		UID:       "gs-mimir",
+		UID:       mimirDatasourceUID,
 		Type:      "prometheus",
 		IsDefault: true,
 		URL:       "http://mimir-gateway.mimir.svc/prometheus",

--- a/pkg/grafana/types.go
+++ b/pkg/grafana/types.go
@@ -44,9 +44,12 @@ func (d Datasource) buildJSONData() map[string]interface{} {
 
 func (d Datasource) buildSecureJSONData(organization Organization) map[string]string {
 	tenantIDs := organization.TenantIDs
-	if d.UID == mimirOldDatasourceUID {
-		// For the old Mimir datasource, we need to use the anonymous tenant
-		tenantIDs = []string{"anonymous"}
+	if d.UID == mimirDatasourceUID {
+		// We do not support multi-tenancy for Mimir yet
+		tenantIDs = common.DefaultReadTenants
+	} else if d.UID == mimirAlertmanagerDatasourceUID {
+		// Alertmanager does not support multi-tenancy
+		tenantIDs = []string{common.DefaultWriteTenant}
 	}
 	return map[string]string{
 		"httpHeaderValue1": strings.Join(tenantIDs, "|"),


### PR DESCRIPTION
This reverts commit 7564f492e64930acd2f297e41373f36df7bbe785 and clean up alertmanager config for the giantswarm tenant

### What this PR does / why we need it


### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
