### PR TITLE
revert pods and configmaps cache tuning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Revert caching tuning for configmaps and pods because it was causing api false answers.
+
 ## [0.19.3] - 2025-03-13
 
 ### Changed

--- a/main.go
+++ b/main.go
@@ -148,23 +148,7 @@ func main() {
 		TLSOpts: tlsOpts,
 	})
 
-	dashboardConfigmapSelector, err := labels.Parse(fmt.Sprintf("%s = %s", controller.DashboardSelectorLabelName, controller.DashboardSelectorLabelValue))
-	if err != nil {
-		setupLog.Error(err, "failed to parse label selector")
-		os.Exit(1)
-	}
-
 	discardHelmSecretsSelector, err := labels.Parse("owner notin (helm,Helm)")
-	if err != nil {
-		setupLog.Error(err, "failed to parse label selector")
-		os.Exit(1)
-	}
-	grafanaPodSelector, err := labels.Parse("app.kubernetes.io/name = grafana")
-	if err != nil {
-		setupLog.Error(err, "failed to parse label selector")
-		os.Exit(1)
-	}
-	mimirAlertmanagerPodSelector, err := labels.Parse("app.kubernetes.io/component = alertmanager, app.kubernetes.io/instance = mimir")
 	if err != nil {
 		setupLog.Error(err, "failed to parse label selector")
 		os.Exit(1)
@@ -194,24 +178,9 @@ func main() {
 		// LeaderElectionReleaseOnCancel: true,
 		Cache: cache.Options{
 			ByObject: map[client.Object]cache.ByObject{
-				&v1.ConfigMap{}: {
-					// Cache only the dashboards configmaps to reduce memory usage.
-					Label: dashboardConfigmapSelector,
-				},
 				&v1.Secret{}: {
 					// Do not cache any helm secrets to reduce memory usage.
 					Label: discardHelmSecretsSelector,
-				},
-				&v1.Pod{}: {
-					// Only cache the grafana and alertmanager pods to reduce memory usage.
-					Namespaces: map[string]cache.Config{
-						"monitoring": {
-							LabelSelector: grafanaPodSelector,
-						},
-						"mimir": {
-							LabelSelector: mimirAlertmanagerPodSelector,
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
### What this PR does / why we need it

Reverts tuning of cache for configmaps and pods, as it was causing the API to lie.
For instance, getting a configmap that was not in the cache could return "Not found" even though the configmap exists.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
