### PR TITLE
run-local: port-forward mimir alertmanager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- updated run-local.sh to port-forward mimir alertmanager
+
 ## [0.19.4] - 2025-03-14
 
 ### Changed

--- a/hack/bin/run-local.sh
+++ b/hack/bin/run-local.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 NAMESPACE="monitoring"
 declare -a OLLYOPARGS
-declare GRAFANAPORTFORWARDPID MIMIRPORTFORWARDPID
+declare GRAFANAPORTFORWARDPID MIMIRPORTFORWARDPID ALERTMANAGERPORTFORWARDPID
 
 
 # Define the arguments for the observability-operator
@@ -54,10 +54,25 @@ function mimirPortForward {
   MIMIRPORTFORWARDPID="$!"
 }
 
-# Stop the Grafana service port-forward
+# Stop the mimir service port-forward
 function stopMimirPortForward {
   childpids=$(ps -o pid= --ppid "$MIMIRPORTFORWARDPID")
   kill "$MIMIRPORTFORWARDPID" || true
+  kill $childpids || true
+}
+
+# Port-forward the alertmanager service
+function alertmanagerPortForward {
+  while true; do
+    kubectl port-forward -n mimir svc/mimir-alertmanager-headless 8181:8080 &>/dev/null || true
+  done &
+  ALERTMANAGERPORTFORWARDPID="$!"
+}
+
+# Stop the alertmanager service port-forward
+function stopAlertmanagerPortForward {
+  childpids=$(ps -o pid= --ppid "$ALERTMANAGERPORTFORWARDPID")
+  kill "$ALERTMANAGERPORTFORWARDPID" || true
   kill $childpids || true
 }
 
@@ -75,6 +90,7 @@ function resumeInClusterOperator {
 function cleanupAtExit {
   stopGrafanaPortForward
   stopMimirPortForward
+  stopAlertmanagerPortForward
   resumeInClusterOperator
 }
 
@@ -93,12 +109,13 @@ function main {
   echo "### starting port-forward"
   grafanaPortForward
   mimirPortForward
+  alertmanagerPortForward
 
   echo "### Pausing in-cluster operator"
   pauseInClusterOperator
 
   echo "### Running operator"
-  go run . "${OLLYOPARGS[@]}" -grafana-url http://localhost:3000 -monitoring-metrics-query-url http://localhost:8180/prometheus
+  go run . "${OLLYOPARGS[@]}" -grafana-url http://localhost:3000 -monitoring-metrics-query-url http://localhost:8180/prometheus -alertmanager-url http://localhost:8181
 
   echo "### Cleanup"
 }


### PR DESCRIPTION
### What this PR does / why we need it

Update run-local to port-forward mimir alertmanager.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
