### PR TITLE
Send Tenet pages to Opsgenie instead of Slack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Send `severity: page` alerts for Tenet to Opsgenie instead of Slack
+
 ## [0.19.4] - 2025-03-14
 
 ### Changed

--- a/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
+++ b/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
@@ -73,7 +73,7 @@ route:
   - receiver: team_tenet_slack
     repeat_interval: 14d
     matchers:
-    - severity=~"page|notify"
+    - severity=~"notify"
     - team=~"tenet|tinkerers"
     continue: false
 


### PR DESCRIPTION
### What this PR does / why we need it

Towards: https://github.com/giantswarm/giantswarm/issues/32822

Sends any `severity: page` alerts for Team Tenet to Opsgenie instead of our Slack channel.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
