### PR TITLE
fix alloy-metrics without vpa support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Set default resources for alloy-metrics only when VPA is enabled.
+
 ## [0.21.0] - 2025-03-24
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -73,7 +73,7 @@ require (
 	golang.org/x/time v0.11.0 // indirect
 	golang.org/x/tools v0.30.0 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.5.0 // indirect
-	google.golang.org/protobuf v1.36.5 // indirect
+	google.golang.org/protobuf v1.36.6 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apiextensions-apiserver v0.32.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -331,8 +331,8 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.65.1 h1:toSN4j5/Xju+HVovfaY5g1YZVuJeHzQZhP8eJ0L0f1I=
 google.golang.org/grpc v1.65.1/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
-google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
-google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
+google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=

--- a/internal/controller/cluster_monitoring_controller.go
+++ b/internal/controller/cluster_monitoring_controller.go
@@ -212,7 +212,7 @@ func (r *ClusterMonitoringReconciler) reconcile(ctx context.Context, cluster *cl
 			}
 		case commonmonitoring.MonitoringAgentAlloy:
 			// Create or update Alloy monitoring configuration.
-			err = r.AlloyService.ReconcileCreate(ctx, cluster)
+			err = r.AlloyService.ReconcileCreate(ctx, cluster, observabilityBundleVersion)
 			if err != nil {
 				logger.Error(err, "failed to create or update alloy monitoring config")
 				return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -14,6 +14,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/Masterminds/sprig/v3"
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 
 	"github.com/giantswarm/observability-operator/pkg/common"
@@ -32,6 +33,8 @@ var (
 	//go:embed templates/monitoring-config.yaml.template
 	alloyMonitoringConfig         string
 	alloyMonitoringConfigTemplate *template.Template
+
+	supportVPA = semver.MustParse("1.7.0")
 )
 
 func init() {
@@ -39,7 +42,7 @@ func init() {
 	alloyMonitoringConfigTemplate = template.Must(template.New("monitoring-config.yaml").Funcs(sprig.FuncMap()).Parse(alloyMonitoringConfig))
 }
 
-func (a *Service) GenerateAlloyMonitoringConfigMapData(ctx context.Context, currentState *v1.ConfigMap, cluster *clusterv1.Cluster, tenants []string) (map[string]string, error) {
+func (a *Service) GenerateAlloyMonitoringConfigMapData(ctx context.Context, currentState *v1.ConfigMap, cluster *clusterv1.Cluster, tenants []string, observabilityBundleVersion semver.Version) (map[string]string, error) {
 	logger := log.FromContext(ctx)
 
 	// Get current number of shards from Alloy's config.
@@ -82,11 +85,16 @@ func (a *Service) GenerateAlloyMonitoringConfigMapData(ctx context.Context, curr
 		PriorityClassName string
 		Replicas          int
 		SecretName        string
+
+		SupportVPA bool
 	}{
 		AlloyConfig:       alloyConfig,
 		PriorityClassName: commonmonitoring.PriorityClassName,
 		Replicas:          shards,
 		SecretName:        commonmonitoring.AlloyMonitoringAgentAppName,
+
+		// Observability bundle in older versions do not support VPA
+		SupportVPA: observabilityBundleVersion.GE(supportVPA),
 	}
 
 	var values bytes.Buffer

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -34,7 +34,7 @@ var (
 	alloyMonitoringConfig         string
 	alloyMonitoringConfigTemplate *template.Template
 
-	supportVPA = semver.MustParse("1.7.0")
+	versionSupportingVPA = semver.MustParse("1.7.0")
 )
 
 func init() {
@@ -86,7 +86,7 @@ func (a *Service) GenerateAlloyMonitoringConfigMapData(ctx context.Context, curr
 		Replicas          int
 		SecretName        string
 
-		SupportVPA bool
+		IsSupportingVPA bool
 	}{
 		AlloyConfig:       alloyConfig,
 		PriorityClassName: commonmonitoring.PriorityClassName,
@@ -94,7 +94,7 @@ func (a *Service) GenerateAlloyMonitoringConfigMapData(ctx context.Context, curr
 		SecretName:        commonmonitoring.AlloyMonitoringAgentAppName,
 
 		// Observability bundle in older versions do not support VPA
-		SupportVPA: observabilityBundleVersion.GE(supportVPA),
+		IsSupportingVPA: observabilityBundleVersion.GE(versionSupportingVPA),
 	}
 
 	var values bytes.Buffer

--- a/pkg/monitoring/alloy/service.go
+++ b/pkg/monitoring/alloy/service.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/blang/semver"
 	"github.com/pkg/errors"
 
 	"github.com/giantswarm/observability-operator/api/v1alpha1"
@@ -33,7 +34,7 @@ type Service struct {
 	MonitoringConfig monitoring.Config
 }
 
-func (a *Service) ReconcileCreate(ctx context.Context, cluster *clusterv1.Cluster) error {
+func (a *Service) ReconcileCreate(ctx context.Context, cluster *clusterv1.Cluster, observabilityBundleVersion semver.Version) error {
 	logger := log.FromContext(ctx)
 	logger.Info("alloy-service - ensuring alloy is configured")
 
@@ -46,7 +47,7 @@ func (a *Service) ReconcileCreate(ctx context.Context, cluster *clusterv1.Cluste
 
 	configmap := ConfigMap(cluster)
 	_, err = controllerutil.CreateOrUpdate(ctx, a.Client, configmap, func() error {
-		data, err := a.GenerateAlloyMonitoringConfigMapData(ctx, configmap, cluster, tenants)
+		data, err := a.GenerateAlloyMonitoringConfigMapData(ctx, configmap, cluster, tenants, observabilityBundleVersion)
 		if err != nil {
 			logger.Error(err, "alloy-service - failed to generate alloy monitoring configmap")
 			return errors.WithStack(err)

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -53,7 +53,7 @@ alloy:
     envFrom:
     - secretRef:
         name: {{ .SecretName }}
-    {{- if .SupportVPA }}
+    {{- if .IsSupportingVPA }}
     # We decided to configure the alloy-metrics resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655#issuecomment-2729636063
     resources:
       limits:
@@ -90,7 +90,7 @@ alloy:
               - alloy
           topologyKey: kubernetes.io/hostname
         weight: 50
-{{- if .SupportVPA }}
+{{- if .IsSupportingVPA }}
 # We decided to configure the alloy-metrics vertical pod autoscaler as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655#issuecomment-2729636063
 verticalPodAutoscaler:
   enabled: true

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -53,6 +53,7 @@ alloy:
     envFrom:
     - secretRef:
         name: {{ .SecretName }}
+    {{- if .SupportVPA }}
     # We decided to configure the alloy-metrics resources as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655#issuecomment-2729636063
     resources:
       limits:
@@ -61,6 +62,7 @@ alloy:
       requests:
         cpu: 25m
         memory: 512Mi
+    {{- end }}
   controller:
     type: statefulset
     replicas: {{ .Replicas }}
@@ -88,6 +90,7 @@ alloy:
               - alloy
           topologyKey: kubernetes.io/hostname
         weight: 50
+{{- if .SupportVPA }}
 # We decided to configure the alloy-metrics vertical pod autoscaler as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655#issuecomment-2729636063
 verticalPodAutoscaler:
   enabled: true
@@ -103,3 +106,4 @@ verticalPodAutoscaler:
       minAllowed:
         cpu: 25m
         memory: 512Mi
+{{- end }}


### PR DESCRIPTION
### What this PR does / why we need it

FIxes an ongoing incident after the release where old alloy metrics pods that were unrestrained and without VPA are now limited to 1 Gi of RAM making them crashloop. This PR ensures we set the limited resources only if the deployed alloy metrics version is using VPA

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
