### PR TITLE
fix incorrect flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix `alloy-rules` app version flag rename forgotten after review.
+
 ## [0.23.0] - 2025-04-07
 
 ### Added

--- a/helm/observability-operator/templates/deployment.yaml
+++ b/helm/observability-operator/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         image: "{{ .Values.image.registry }}/{{ .Values.image.name }}:{{ default .Chart.Version .Values.image.tag }}"
         args:
         - --leader-elect
-        - --alloy-app-version={{ .Values.alloy.appVersion }}
+        - --alloy-rules-app-version={{ .Values.alloy.appVersion }}
         - --management-cluster-base-domain={{ $.Values.managementCluster.baseDomain }}
         - --management-cluster-customer={{ $.Values.managementCluster.customer }}
         - --management-cluster-insecure-ca={{ $.Values.managementCluster.insecureCA }}


### PR DESCRIPTION
### What this PR does / why we need it

Fixes this:

 k logs -n monitoring observability-operator-b4b946c4d-hx92v
flag provided but not defined: -alloy-app-version
Usage of /observability-operator:
  -alertmanager-enabled
    	Enable Alertmanager controller.
  -alertmanager-secret-name string
    	The name of the secret containing the Alertmanager configuration.
  -alertmanager-url string
    	The URL of the Alertmanager API.
  -alloy-rules-app-version string
    	Version of the alloy to use for alloy-rules (default "0.9.0")


### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
