### PR TITLE
prevent deletion of grafanaorganization CRD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Add `helm.sh/resource-policy: keep` annotation on the grafana organization CRD to prevent it's deletion.
+
 ## [0.23.2] - 2025-04-07
 
 ### Fixed

--- a/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
+++ b/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
@@ -4,6 +4,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.17.3
+    helm.sh/resource-policy: keep
   name: grafanaorganizations.observability.giantswarm.io
 spec:
   group: observability.giantswarm.io


### PR DESCRIPTION
### What this PR does / why we need it

This pull request includes changes to add a new annotation to the Grafana organization CustomResourceDefinition (CRD) to prevent its deletion when we delete the chart as discussed https://gigantic.slack.com/archives/CLPMFRVU6/p1744615642845669

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
