### PR TITLE
load prometheus rules from workload clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add support for loading rules in a tenant in the Mimir Ruler from Workload Clusters.
+
 ## [0.24.0] - 2025-04-15
 
 ### Changed

--- a/pkg/common/monitoring/monitoring.go
+++ b/pkg/common/monitoring/monitoring.go
@@ -40,7 +40,8 @@ const (
 	QueueConfigSampleAgeLimit    = "30m"
 
 	RemoteWriteName                = "mimir"
-	RemoteWriteEndpointTemplateURL = "https://mimir.%s/api/v1/push"
+	MimirBaseUrl                   = "https://mimir.%s"
+	RemoteWriteEndpointTemplateURL = MimirBaseUrl + "/api/v1/push"
 	RemoteWriteTimeout             = "60s"
 
 	OrgIDHeader        = "X-Scope-OrgID"

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -47,11 +47,15 @@ type ManagementCluster struct {
 	Region string
 }
 
+func IsWorkloadCluster(cluster *clusterv1.Cluster, mc ManagementCluster) bool {
+	return cluster.Name != mc.Name
+}
+
 func GetClusterType(cluster *clusterv1.Cluster, mc ManagementCluster) string {
-	if cluster.Name == mc.Name {
-		return "management_cluster"
+	if IsWorkloadCluster(cluster, mc) {
+		return "workload_cluster"
 	}
-	return "workload_cluster"
+	return "management_cluster"
 }
 
 func GetClusterProvider(cluster *clusterv1.Cluster) (string, error) {

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -123,12 +123,16 @@ func (a *Service) generateAlloyConfig(ctx context.Context, cluster *clusterv1.Cl
 	}
 
 	data := struct {
+		RulerAPIURLEnvVarName                  string
 		RemoteWriteURLEnvVarName               string
 		RemoteWriteNameEnvVarName              string
 		RemoteWriteBasicAuthUsernameEnvVarName string
 		RemoteWriteBasicAuthPasswordEnvVarName string
 		RemoteWriteTimeout                     string
 		RemoteWriteTLSInsecureSkipVerify       bool
+
+		ClusterName       string
+		IsWorkloadCluster bool
 
 		Tenants         []string
 		DefaultTenantID string
@@ -142,12 +146,16 @@ func (a *Service) generateAlloyConfig(ctx context.Context, cluster *clusterv1.Cl
 
 		ExternalLabels map[string]string
 	}{
+		RulerAPIURLEnvVarName:                  AlloyRulerAPIURLEnvVarName,
 		RemoteWriteURLEnvVarName:               AlloyRemoteWriteURLEnvVarName,
 		RemoteWriteNameEnvVarName:              AlloyRemoteWriteNameEnvVarName,
 		RemoteWriteBasicAuthUsernameEnvVarName: AlloyRemoteWriteBasicAuthUsernameEnvVarName,
 		RemoteWriteBasicAuthPasswordEnvVarName: AlloyRemoteWriteBasicAuthPasswordEnvVarName,
 		RemoteWriteTimeout:                     commonmonitoring.RemoteWriteTimeout,
 		RemoteWriteTLSInsecureSkipVerify:       a.ManagementCluster.InsecureCA,
+
+		ClusterName:       cluster.Name,
+		IsWorkloadCluster: common.IsWorkloadCluster(cluster, a.ManagementCluster),
 
 		Tenants:         tenants,
 		DefaultTenantID: commonmonitoring.DefaultWriteTenant,

--- a/pkg/monitoring/alloy/configmap_test.go
+++ b/pkg/monitoring/alloy/configmap_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/giantswarm/observability-operator/pkg/monitoring"
 )
 
+var managementClusterName = "dummy-cluster"
+
 // dummyOrgRepo implements a minimal OrganizationRepository.
 type dummyOrgRepo struct{}
 
@@ -31,7 +33,7 @@ func TestGenerateAlloyConfig(t *testing.T) {
 		goldenPath string
 	}{
 		{
-			name: "TwoTenants",
+			name: "TwoTenantsInWC",
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-cluster",
@@ -44,10 +46,26 @@ func TestGenerateAlloyConfig(t *testing.T) {
 				},
 			},
 			tenants:    []string{"tenant1", "tenant2"},
-			goldenPath: filepath.Join("testdata", "alloy_config_multitenants.river"),
+			goldenPath: filepath.Join("testdata", "alloy_config_multitenants.wc.river"),
 		},
 		{
-			name: "SingleTenant",
+			name: "TwoTenantsInMC",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managementClusterName,
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Kind: "AWSCluster",
+					},
+				},
+			},
+			tenants:    []string{"tenant1", "tenant2"},
+			goldenPath: filepath.Join("testdata", "alloy_config_multitenants.mc.river"),
+		},
+		{
+			name: "SingleTenantInWC",
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "single-tenant-cluster",
@@ -60,10 +78,26 @@ func TestGenerateAlloyConfig(t *testing.T) {
 				},
 			},
 			tenants:    []string{"tenant1"},
-			goldenPath: filepath.Join("testdata", "alloy_config_singletenant.river"),
+			goldenPath: filepath.Join("testdata", "alloy_config_singletenant.wc.river"),
 		},
 		{
-			name: "DefaultTenantRendersLegacyConfig",
+			name: "SingleTenantInMC",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managementClusterName,
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Kind: "AzureCluster",
+					},
+				},
+			},
+			tenants:    []string{"tenant1"},
+			goldenPath: filepath.Join("testdata", "alloy_config_singletenant.mc.river"),
+		},
+		{
+			name: "DefaultTenantRendersLegacyConfigInWC",
 			cluster: &clusterv1.Cluster{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "default-tenant-cluster",
@@ -76,7 +110,23 @@ func TestGenerateAlloyConfig(t *testing.T) {
 				},
 			},
 			tenants:    []string{commonmonitoring.DefaultWriteTenant},
-			goldenPath: filepath.Join("testdata", "alloy_config_defaulttenant.river"),
+			goldenPath: filepath.Join("testdata", "alloy_config_defaulttenant.wc.river"),
+		},
+		{
+			name: "DefaultTenantRendersLegacyConfigInMC",
+			cluster: &clusterv1.Cluster{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      managementClusterName,
+					Namespace: "default",
+				},
+				Spec: clusterv1.ClusterSpec{
+					InfrastructureRef: &corev1.ObjectReference{
+						Kind: "AzureCluster",
+					},
+				},
+			},
+			tenants:    []string{commonmonitoring.DefaultWriteTenant},
+			goldenPath: filepath.Join("testdata", "alloy_config_defaulttenant.mc.river"),
 		},
 	}
 

--- a/pkg/monitoring/alloy/secret.go
+++ b/pkg/monitoring/alloy/secret.go
@@ -19,6 +19,7 @@ import (
 )
 
 const (
+	AlloyRulerAPIURLEnvVarName                  = "RULER_API_URL"
 	AlloyRemoteWriteURLEnvVarName               = "REMOTE_WRITE_URL"
 	AlloyRemoteWriteNameEnvVarName              = "REMOTE_WRITE_NAME"
 	AlloyRemoteWriteBasicAuthUsernameEnvVarName = "BASIC_AUTH_USERNAME"
@@ -36,17 +37,20 @@ func init() {
 }
 
 func (a *Service) GenerateAlloyMonitoringSecretData(ctx context.Context, cluster *clusterv1.Cluster) (map[string][]byte, error) {
-	url := fmt.Sprintf(commonmonitoring.RemoteWriteEndpointTemplateURL, a.ManagementCluster.BaseDomain)
+	remoteWriteUrl := fmt.Sprintf(commonmonitoring.RemoteWriteEndpointTemplateURL, a.ManagementCluster.BaseDomain)
 	password, err := commonmonitoring.GetMimirIngressPassword(ctx)
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}
 
+	mimirRulerUrl := fmt.Sprintf(commonmonitoring.MimirBaseUrl, a.ManagementCluster.BaseDomain)
+
 	data := []struct {
 		Name  string
 		Value string
 	}{
-		{Name: AlloyRemoteWriteURLEnvVarName, Value: url},
+		{Name: AlloyRulerAPIURLEnvVarName, Value: mimirRulerUrl},
+		{Name: AlloyRemoteWriteURLEnvVarName, Value: remoteWriteUrl},
 		{Name: AlloyRemoteWriteNameEnvVarName, Value: commonmonitoring.RemoteWriteName},
 		{Name: AlloyRemoteWriteBasicAuthUsernameEnvVarName, Value: a.ManagementCluster.Name},
 		{Name: AlloyRemoteWriteBasicAuthPasswordEnvVarName, Value: password},

--- a/pkg/monitoring/alloy/templates/alloy-config.alloy.template
+++ b/pkg/monitoring/alloy/templates/alloy-config.alloy.template
@@ -3,8 +3,40 @@ logging {
   format = "logfmt"
 }
 
+{{- if $.IsWorkloadCluster }}
+{{- range .Tenants }}
+// load rules for tenant {{ . }}
+mimir.rules.kubernetes "{{ . }}" {
+  address = env("{{ $.RulerAPIURLEnvVarName }}")
+  basic_auth {
+    username = env("{{ $.RemoteWriteBasicAuthUsernameEnvVarName }}")
+    password = env("{{ $.RemoteWriteBasicAuthPasswordEnvVarName }}")
+  }
+  extra_query_matchers {
+    matcher {
+        name = "cluster_id"
+        match_type = "="
+        value = "{{ $.ClusterName }}"
+    }
+  }
+  mimir_namespace_prefix = "{{ $.ClusterName }}"
+  tenant_id = "{{ . }}"
+  rule_selector {
+      match_labels = {
+        "observability.giantswarm.io/tenant" = "{{ . }}",
+      }
+      match_expression {
+        key = "application.giantswarm.io/prometheus-rule-kind"
+        operator = "NotIn"
+        values = ["loki"]
+      }
+  }
+}
+{{- end }}
+{{- end }}
+
 // we create a podmonitor and servicemonitor component per tenant because we cannot read pod/service monitor labels through relabelling.
-{{ range .Tenants }}
+{{- range .Tenants }}
 // remote write pipeline configuration for tenant {{ . }}
 {{- if eq . $.DefaultTenantID }}
 prometheus.operator.servicemonitors "{{ . }}_legacy" {

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
@@ -1,0 +1,123 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+// we create a podmonitor and servicemonitor component per tenant because we cannot read pod/service monitor labels through relabelling.
+// remote write pipeline configuration for tenant giantswarm
+prometheus.operator.servicemonitors "giantswarm_legacy" {
+  forward_to = [prometheus.remote_write.giantswarm.receiver]
+  selector {
+    match_expression {
+      key      = "application.giantswarm.io/team"
+      operator = "Exists"
+    }
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "DoesNotExist"
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.operator.podmonitors "giantswarm_legacy" {
+  forward_to = [prometheus.remote_write.giantswarm.receiver]
+  selector {
+    match_expression {
+      key      = "application.giantswarm.io/team"
+      operator = "Exists"
+    }
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "DoesNotExist"
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+
+prometheus.operator.servicemonitors "giantswarm" {
+  forward_to = [prometheus.remote_write.giantswarm.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["giantswarm"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.operator.podmonitors "giantswarm" {
+  forward_to = [prometheus.remote_write.giantswarm.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["giantswarm"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+// remote write pipeline configuration for tenant giantswarm
+prometheus.remote_write "giantswarm" {
+  endpoint {
+    url            = env("REMOTE_WRITE_URL")
+    name           = env("REMOTE_WRITE_NAME")
+    enable_http2   = false
+    remote_timeout = "60s"
+    basic_auth {
+      username = env("BASIC_AUTH_USERNAME")
+      password = env("BASIC_AUTH_PASSWORD")
+    }
+    headers = {
+      "X-Scope-OrgID" = "giantswarm",
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    queue_config {
+      capacity             = 30000
+      max_shards           = 10
+      max_samples_per_send = 150000
+      sample_age_limit     = "30m"
+    }
+  }
+  wal {
+    truncate_frequency = "1m0s"
+  }
+  external_labels = {
+    "cluster_id" = "dummy-cluster",
+    "cluster_type" = "management_cluster",
+    "customer" = "dummy-customer",
+    "installation" = "dummy-cluster",
+    "organization" = "dummy-org",
+    "pipeline" = "dummy-pipeline",
+    "provider" = "capz",
+    "region" = "dummy-region",
+    "service_priority" = "highest",
+  }
+}
+
+

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
@@ -2,9 +2,35 @@ logging {
   level  = "info"
   format = "logfmt"
 }
+// load rules for tenant giantswarm
+mimir.rules.kubernetes "giantswarm" {
+  address = env("RULER_API_URL")
+  basic_auth {
+    username = env("BASIC_AUTH_USERNAME")
+    password = env("BASIC_AUTH_PASSWORD")
+  }
+  extra_query_matchers {
+    matcher {
+        name = "cluster_id"
+        match_type = "="
+        value = "default-tenant-cluster"
+    }
+  }
+  mimir_namespace_prefix = "default-tenant-cluster"
+  tenant_id = "giantswarm"
+  rule_selector {
+      match_labels = {
+        "observability.giantswarm.io/tenant" = "giantswarm",
+      }
+      match_expression {
+        key = "application.giantswarm.io/prometheus-rule-kind"
+        operator = "NotIn"
+        values = ["loki"]
+      }
+  }
+}
 
 // we create a podmonitor and servicemonitor component per tenant because we cannot read pod/service monitor labels through relabelling.
-
 // remote write pipeline configuration for tenant giantswarm
 prometheus.operator.servicemonitors "giantswarm_legacy" {
   forward_to = [prometheus.remote_write.giantswarm.receiver]

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
@@ -1,0 +1,160 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+// we create a podmonitor and servicemonitor component per tenant because we cannot read pod/service monitor labels through relabelling.
+// remote write pipeline configuration for tenant tenant1
+
+prometheus.operator.servicemonitors "tenant1" {
+  forward_to = [prometheus.remote_write.tenant1.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["tenant1"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.operator.podmonitors "tenant1" {
+  forward_to = [prometheus.remote_write.tenant1.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["tenant1"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+// remote write pipeline configuration for tenant tenant1
+prometheus.remote_write "tenant1" {
+  endpoint {
+    url            = env("REMOTE_WRITE_URL")
+    name           = env("REMOTE_WRITE_NAME")
+    enable_http2   = false
+    remote_timeout = "60s"
+    basic_auth {
+      username = env("BASIC_AUTH_USERNAME")
+      password = env("BASIC_AUTH_PASSWORD")
+    }
+    headers = {
+      "X-Scope-OrgID" = "tenant1",
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    queue_config {
+      capacity             = 30000
+      max_shards           = 10
+      max_samples_per_send = 150000
+      sample_age_limit     = "30m"
+    }
+  }
+  wal {
+    truncate_frequency = "1m0s"
+  }
+  external_labels = {
+    "cluster_id" = "dummy-cluster",
+    "cluster_type" = "management_cluster",
+    "customer" = "dummy-customer",
+    "installation" = "dummy-cluster",
+    "organization" = "dummy-org",
+    "pipeline" = "dummy-pipeline",
+    "provider" = "capa",
+    "region" = "dummy-region",
+    "service_priority" = "highest",
+  }
+}
+
+
+// remote write pipeline configuration for tenant tenant2
+
+prometheus.operator.servicemonitors "tenant2" {
+  forward_to = [prometheus.remote_write.tenant2.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["tenant2"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.operator.podmonitors "tenant2" {
+  forward_to = [prometheus.remote_write.tenant2.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["tenant2"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+// remote write pipeline configuration for tenant tenant2
+prometheus.remote_write "tenant2" {
+  endpoint {
+    url            = env("REMOTE_WRITE_URL")
+    name           = env("REMOTE_WRITE_NAME")
+    enable_http2   = false
+    remote_timeout = "60s"
+    basic_auth {
+      username = env("BASIC_AUTH_USERNAME")
+      password = env("BASIC_AUTH_PASSWORD")
+    }
+    headers = {
+      "X-Scope-OrgID" = "tenant2",
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    queue_config {
+      capacity             = 30000
+      max_shards           = 10
+      max_samples_per_send = 150000
+      sample_age_limit     = "30m"
+    }
+  }
+  wal {
+    truncate_frequency = "1m0s"
+  }
+  external_labels = {
+    "cluster_id" = "dummy-cluster",
+    "cluster_type" = "management_cluster",
+    "customer" = "dummy-customer",
+    "installation" = "dummy-cluster",
+    "organization" = "dummy-org",
+    "pipeline" = "dummy-pipeline",
+    "provider" = "capa",
+    "region" = "dummy-region",
+    "service_priority" = "highest",
+  }
+}
+
+

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
@@ -2,9 +2,62 @@ logging {
   level  = "info"
   format = "logfmt"
 }
+// load rules for tenant tenant1
+mimir.rules.kubernetes "tenant1" {
+  address = env("RULER_API_URL")
+  basic_auth {
+    username = env("BASIC_AUTH_USERNAME")
+    password = env("BASIC_AUTH_PASSWORD")
+  }
+  extra_query_matchers {
+    matcher {
+        name = "cluster_id"
+        match_type = "="
+        value = "test-cluster"
+    }
+  }
+  mimir_namespace_prefix = "test-cluster"
+  tenant_id = "tenant1"
+  rule_selector {
+      match_labels = {
+        "observability.giantswarm.io/tenant" = "tenant1",
+      }
+      match_expression {
+        key = "application.giantswarm.io/prometheus-rule-kind"
+        operator = "NotIn"
+        values = ["loki"]
+      }
+  }
+}
+// load rules for tenant tenant2
+mimir.rules.kubernetes "tenant2" {
+  address = env("RULER_API_URL")
+  basic_auth {
+    username = env("BASIC_AUTH_USERNAME")
+    password = env("BASIC_AUTH_PASSWORD")
+  }
+  extra_query_matchers {
+    matcher {
+        name = "cluster_id"
+        match_type = "="
+        value = "test-cluster"
+    }
+  }
+  mimir_namespace_prefix = "test-cluster"
+  tenant_id = "tenant2"
+  rule_selector {
+      match_labels = {
+        "observability.giantswarm.io/tenant" = "tenant2",
+      }
+      match_expression {
+        key = "application.giantswarm.io/prometheus-rule-kind"
+        operator = "NotIn"
+        values = ["loki"]
+      }
+  }
+}
 
 // we create a podmonitor and servicemonitor component per tenant because we cannot read pod/service monitor labels through relabelling.
-
 // remote write pipeline configuration for tenant tenant1
 
 prometheus.operator.servicemonitors "tenant1" {

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
@@ -1,0 +1,83 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+// we create a podmonitor and servicemonitor component per tenant because we cannot read pod/service monitor labels through relabelling.
+// remote write pipeline configuration for tenant tenant1
+
+prometheus.operator.servicemonitors "tenant1" {
+  forward_to = [prometheus.remote_write.tenant1.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["tenant1"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+prometheus.operator.podmonitors "tenant1" {
+  forward_to = [prometheus.remote_write.tenant1.receiver]
+  selector {
+    match_expression {
+      key      = "observability.giantswarm.io/tenant"
+      operator = "In"
+      values   = ["tenant1"]
+    }
+  }
+  scrape {
+    default_scrape_interval = "60s"
+  }
+  clustering {
+    enabled = true
+  }
+}
+
+// remote write pipeline configuration for tenant tenant1
+prometheus.remote_write "tenant1" {
+  endpoint {
+    url            = env("REMOTE_WRITE_URL")
+    name           = env("REMOTE_WRITE_NAME")
+    enable_http2   = false
+    remote_timeout = "60s"
+    basic_auth {
+      username = env("BASIC_AUTH_USERNAME")
+      password = env("BASIC_AUTH_PASSWORD")
+    }
+    headers = {
+      "X-Scope-OrgID" = "tenant1",
+    }
+    tls_config {
+      insecure_skip_verify = false
+    }
+    queue_config {
+      capacity             = 30000
+      max_shards           = 10
+      max_samples_per_send = 150000
+      sample_age_limit     = "30m"
+    }
+  }
+  wal {
+    truncate_frequency = "1m0s"
+  }
+  external_labels = {
+    "cluster_id" = "dummy-cluster",
+    "cluster_type" = "management_cluster",
+    "customer" = "dummy-customer",
+    "installation" = "dummy-cluster",
+    "organization" = "dummy-org",
+    "pipeline" = "dummy-pipeline",
+    "provider" = "capz",
+    "region" = "dummy-region",
+    "service_priority" = "highest",
+  }
+}
+
+

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
@@ -2,9 +2,35 @@ logging {
   level  = "info"
   format = "logfmt"
 }
+// load rules for tenant tenant1
+mimir.rules.kubernetes "tenant1" {
+  address = env("RULER_API_URL")
+  basic_auth {
+    username = env("BASIC_AUTH_USERNAME")
+    password = env("BASIC_AUTH_PASSWORD")
+  }
+  extra_query_matchers {
+    matcher {
+        name = "cluster_id"
+        match_type = "="
+        value = "single-tenant-cluster"
+    }
+  }
+  mimir_namespace_prefix = "single-tenant-cluster"
+  tenant_id = "tenant1"
+  rule_selector {
+      match_labels = {
+        "observability.giantswarm.io/tenant" = "tenant1",
+      }
+      match_expression {
+        key = "application.giantswarm.io/prometheus-rule-kind"
+        operator = "NotIn"
+        values = ["loki"]
+      }
+  }
+}
 
 // we create a podmonitor and servicemonitor component per tenant because we cannot read pod/service monitor labels through relabelling.
-
 // remote write pipeline configuration for tenant tenant1
 
 prometheus.operator.servicemonitors "tenant1" {


### PR DESCRIPTION
### What this PR does / why we need it

This pull request introduces changes to support loading prometheus rules in a tenant in the Mimir Ruler from Workload Clusters via alloy-metrics. To that end, this PR adds new MC/WC golden files for alloy-metrics config to differentiate between WC and MC configs for as long as we have a difference in configuration.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
