### PR TITLE
fix blackhole for stable-testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix alertmanager configuration to not drop alerts when stable-testing management cluster's default apps are failing.
+
 ### Removed
 
 - Remove alloy-rules deletion code which is no longer needed since the last release.

--- a/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
+++ b/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
@@ -40,15 +40,7 @@ route:
     continue: false
   - receiver: blackhole
     matchers:
-    - alertname=~"WorkloadClusterApp.*"
-    continue: false
-  - receiver: blackhole
-    matchers:
-    - alertname="PrometheusMetaOperatorReconcileErrors"
-    continue: false
-  - receiver: blackhole
-    matchers:
-    - alertname="ClusterUnhealthyPhase"
+    - alertname=~"ClusterUnhealthyPhase|PrometheusMetaOperatorReconcileErrors|WorkloadClusterApp.*"
     continue: false
   - receiver: blackhole
     matchers:
@@ -60,7 +52,7 @@ route:
   - receiver: blackhole
     matchers:
     - alertname="ManagementClusterAppFailed"
-    - namespace=~"org-.*"
+    - namespace=~"org-([^g]|g[^i]|gi[^a]|gia[^n]|gian[^t]|giant[^s]|giants[^w]|giantsw[^a]|giantswa[^r]|giantswar[^m])+"
     continue: false
   {{- end }}
 


### PR DESCRIPTION
### What this PR does / why we need it

This pull request addresses issues with alert routing in the Alertmanager configuration and includes a bug fix noted in the changelog. The changes aim to ensure we are paged if a managementcluster apps in the org-giantswarm namespace is failing.


### Alertmanager Configuration Updates:

* Consolidated alert routing rules by combining matchers for `ClusterUnhealthyPhase`, `PrometheusMetaOperatorReconcileErrors`, and `WorkloadClusterApp.*` into a single rule to simplify configuration (`helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template`).
* Refined the namespace matcher for the `ManagementClusterAppFailed` alert to exclude namespaces starting with "giantswarm" more precisely, using a regex pattern (`helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template`).

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
