### PR TITLE
alertmanager vintage inhibitions cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated alertmanager's inhibitions, getting rid of vintage-specifics.
+
 ## [0.29.0] - 2025-05-05
 
 ### Changed

--- a/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
+++ b/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
@@ -329,54 +329,6 @@ inhibit_rules:
   - cancel_if_any_kube_state_metrics_down=true
 
 - source_matchers:
-  - cluster_status_creating=true
-  target_matchers:
-  - cancel_if_cluster_status_creating=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - cluster_status_created=true
-  target_matchers:
-  - cancel_if_cluster_status_created=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - cluster_status_updating=true
-  target_matchers:
-  - cancel_if_cluster_status_updating=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - cluster_status_updated=true
-  target_matchers:
-  - cancel_if_cluster_status_updated=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - cluster_status_deleting=true
-  target_matchers:
-  - cancel_if_cluster_status_deleting=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - cluster_with_no_nodepools=true
-  target_matchers:
-  - cancel_if_cluster_with_no_nodepools=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - cluster_with_scaling_nodepools=true
-  target_matchers:
-  - cancel_if_cluster_with_scaling_nodepools=true
-  equal: [cluster_id]
-
-- source_matchers:
-  - cluster_with_notready_nodepools=true
-  target_matchers:
-  - cancel_if_cluster_with_notready_nodepools=true
-  equal: [cluster_id]
-
-- source_matchers:
   - cluster_control_plane_unhealthy=true
   target_matchers:
   - cancel_if_cluster_control_plane_unhealthy=true
@@ -386,18 +338,6 @@ inhibit_rules:
   - cluster_control_plane_unhealthy=true
   target_matchers:
   - cancel_if_any_cluster_control_plane_unhealthy=true
-
-- source_matchers:
-  - instance_state_not_running=true
-  target_matchers:
-  - cancel_if_instance_state_not_running=true
-  equal: [node]
-
-- source_matchers:
-  - kiam_has_errors=true
-  target_matchers:
-  - cancel_if_kiam_has_errors=true
-  equal: [cluster_id]
 
 - source_matchers:
   - kubelet_down=true
@@ -423,21 +363,10 @@ inhibit_rules:
   equal: [cluster_id]
 
 - source_matchers:
-    - cluster_is_not_running_monitoring_agent=true
-  target_matchers:
-    - cancel_if_cluster_is_not_running_monitoring_agent=true
-  equal: [cluster_id]
-
-- source_matchers:
     - inhibit_monitoring_agent_down=true
   target_matchers:
     - cancel_if_monitoring_agent_down=true
   equal: [cluster_id]
-
-- source_matchers:
-    - stack_failed=true
-  target_matchers:
-    - cancel_if_stack_failed=true
 
 # Source: https://github.com/giantswarm/prometheus-rules/blob/main/helm/prometheus-rules/templates/kaas/turtles/alerting-rules/inhibit.nodes.rules.yml
 - source_matchers:


### PR DESCRIPTION
### What this PR does / why we need it

Now vintage is deprecated / frozen we don't have these inhibition sources anymore.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
