### PR TITLE
Unify finalizer logic across controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Unify finalizer logic accross controllers
+
 ## [0.30.0] - 2025-05-14
 
 ### Removed

--- a/internal/controller/finalizer.go
+++ b/internal/controller/finalizer.go
@@ -10,8 +10,24 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-func ensureFinalizerdAdded(ctx context.Context, runtimeClient client.Client, object client.Object, finalizer string) (bool, error) {
-	if controllerutil.ContainsFinalizer(object, finalizer) {
+type FinalizerHelper struct {
+	// runtimeClient is the client used to interact with the Kubernetes API
+	runtimeClient client.Client
+	// finalizer is the finalizer string to be added/removed
+	finalizer string
+}
+
+func NewFinalizerHelper(runtimeClient client.Client, finalizer string) FinalizerHelper {
+	fh := FinalizerHelper{
+		runtimeClient: runtimeClient,
+		finalizer:     finalizer,
+	}
+
+	return fh
+}
+
+func (fh FinalizerHelper) EnsureAdded(ctx context.Context, object client.Object) (bool, error) {
+	if controllerutil.ContainsFinalizer(object, fh.finalizer) {
 		// Finalizer already exists, no need to add it
 		return false, nil
 	}
@@ -20,45 +36,45 @@ func ensureFinalizerdAdded(ctx context.Context, runtimeClient client.Client, obj
 
 	// We use a patch rather than an update to avoid conflicts when multiple controllers are adding their finalizer
 	// We use the patch from sigs.k8s.io/cluster-api/util/patch to handle the patching without conflicts
-	logger.Info("adding finalizer", "finalizer", finalizer)
-	patchHelper, err := patch.NewHelper(object, runtimeClient)
+	logger.Info("adding finalizer", "finalizer", fh.finalizer)
+	patchHelper, err := patch.NewHelper(object, fh.runtimeClient)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
 
 	// Add the finalizer to the object
-	controllerutil.AddFinalizer(object, finalizer)
+	controllerutil.AddFinalizer(object, fh.finalizer)
 
 	err = patchHelper.Patch(ctx, object)
 	if err != nil {
-		logger.Error(err, "failed to add finalizer", "finalizer", finalizer)
+		logger.Error(err, "failed to add finalizer", "finalizer", fh.finalizer)
 		return false, errors.WithStack(err)
 	}
 
-	logger.Info("added finalizer", "finalizer", finalizer)
+	logger.Info("added finalizer", "finalizer", fh.finalizer)
 	return true, nil
 }
 
-func ensureFinalizerRemoved(ctx context.Context, runtimeClient client.Client, object client.Object, finalizer string) error {
+func (fh FinalizerHelper) EnsureRemoved(ctx context.Context, object client.Object) error {
 	logger := log.FromContext(ctx)
 
 	// We use the patch from sigs.k8s.io/cluster-api/util/patch to handle the patching without conflicts
-	logger.Info("removing finalizer", "finalizer", finalizer)
-	patchHelper, err := patch.NewHelper(object, runtimeClient)
+	logger.Info("removing finalizer", "finalizer", fh.finalizer)
+	patchHelper, err := patch.NewHelper(object, fh.runtimeClient)
 	if err != nil {
 		return errors.WithStack(err)
 	}
 
 	// Remove the finalizer from the object
-	controllerutil.RemoveFinalizer(object, finalizer)
+	controllerutil.RemoveFinalizer(object, fh.finalizer)
 
 	err = patchHelper.Patch(ctx, object)
 	if err != nil {
-		logger.Error(err, "failed to remove finalizer", "finalizer", finalizer)
+		logger.Error(err, "failed to remove finalizer", "finalizer", fh.finalizer)
 		return errors.WithStack(err)
 	}
 
-	logger.Info("removed finalizer", "finalizer", finalizer)
+	logger.Info("removed finalizer", "finalizer", fh.finalizer)
 
 	return nil
 }

--- a/internal/controller/finalizer.go
+++ b/internal/controller/finalizer.go
@@ -1,0 +1,40 @@
+package controller
+
+import (
+	"context"
+
+	"github.com/pkg/errors"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func ensureFinalizerdAdded(ctx context.Context, runtimeClient client.Client, object client.Object, finalizer string) (bool, error) {
+	if controllerutil.ContainsFinalizer(object, finalizer) {
+		// Finalizer already exists, no need to add it
+		return false, nil
+	}
+
+	logger := log.FromContext(ctx)
+
+	// We use a patch rather than an update to avoid conflicts when multiple controllers are adding their finalizer
+	// We use the patch from sigs.k8s.io/cluster-api/util/patch to handle the patching without conflicts
+	logger.Info("adding finalizer", "finalizer", finalizer)
+	patchHelper, err := patch.NewHelper(object, runtimeClient)
+	if err != nil {
+		return false, errors.WithStack(err)
+	}
+
+	// Add the finalizer to the object
+	controllerutil.AddFinalizer(object, finalizer)
+
+	err = patchHelper.Patch(ctx, object)
+	if err != nil {
+		logger.Error(err, "failed to add finalizer", "finalizer", finalizer)
+		return false, errors.WithStack(err)
+	}
+
+	logger.Info("added finalizer", "finalizer", finalizer)
+	return true, nil
+}

--- a/internal/controller/finalizer.go
+++ b/internal/controller/finalizer.go
@@ -11,16 +11,16 @@ import (
 )
 
 type FinalizerHelper struct {
-	// runtimeClient is the client used to interact with the Kubernetes API
-	runtimeClient client.Client
+	// client is the client used to interact with the Kubernetes API
+	client client.Client
 	// finalizer is the finalizer string to be added/removed
 	finalizer string
 }
 
 func NewFinalizerHelper(runtimeClient client.Client, finalizer string) FinalizerHelper {
 	fh := FinalizerHelper{
-		runtimeClient: runtimeClient,
-		finalizer:     finalizer,
+		client:    runtimeClient,
+		finalizer: finalizer,
 	}
 
 	return fh
@@ -37,7 +37,7 @@ func (fh FinalizerHelper) EnsureAdded(ctx context.Context, object client.Object)
 	// We use a patch rather than an update to avoid conflicts when multiple controllers are adding their finalizer
 	// We use the patch from sigs.k8s.io/cluster-api/util/patch to handle the patching without conflicts
 	logger.Info("adding finalizer", "finalizer", fh.finalizer)
-	patchHelper, err := patch.NewHelper(object, fh.runtimeClient)
+	patchHelper, err := patch.NewHelper(object, fh.client)
 	if err != nil {
 		return false, errors.WithStack(err)
 	}
@@ -60,7 +60,7 @@ func (fh FinalizerHelper) EnsureRemoved(ctx context.Context, object client.Objec
 
 	// We use the patch from sigs.k8s.io/cluster-api/util/patch to handle the patching without conflicts
 	logger.Info("removing finalizer", "finalizer", fh.finalizer)
-	patchHelper, err := patch.NewHelper(object, fh.runtimeClient)
+	patchHelper, err := patch.NewHelper(object, fh.client)
 	if err != nil {
 		return errors.WithStack(err)
 	}


### PR DESCRIPTION
Follow-up on: https://github.com/giantswarm/observability-operator/pull/388

This PR add new `ensureFinalizerAdded` and `ensureFinalizerRemoved` methods to encapsulate the logic of adding and removing finalizers. This is done to avoid code duplication and make the code more maintainable.
It does replace the logic for finalizers in-place in cluster, dashboard, and organization controllers.