### PR TITLE
Add team label to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add team labels to metrics coming from ServiceMonitors and PodMonitors
+
 ## [0.31.0] - 2025-05-15
 
 ### Changed

--- a/pkg/monitoring/alloy/templates/alloy-config.alloy.template
+++ b/pkg/monitoring/alloy/templates/alloy-config.alloy.template
@@ -60,6 +60,11 @@ prometheus.operator.servicemonitors "{{ . }}_legacy" {
       operator = "DoesNotExist"
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -80,6 +85,11 @@ prometheus.operator.podmonitors "{{ . }}_legacy" {
       operator = "DoesNotExist"
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -98,6 +108,11 @@ prometheus.operator.servicemonitors "{{ . }}" {
       values   = ["{{ . }}"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -114,6 +129,11 @@ prometheus.operator.podmonitors "{{ . }}" {
       operator = "In"
       values   = ["{{ . }}"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/templates/alloy-config.alloy.template
+++ b/pkg/monitoring/alloy/templates/alloy-config.alloy.template
@@ -65,6 +65,16 @@ prometheus.operator.servicemonitors "{{ . }}_legacy" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -90,6 +100,16 @@ prometheus.operator.podmonitors "{{ . }}_legacy" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -113,6 +133,16 @@ prometheus.operator.servicemonitors "{{ . }}" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -134,6 +164,16 @@ prometheus.operator.podmonitors "{{ . }}" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
@@ -38,6 +38,11 @@ prometheus.operator.servicemonitors "giantswarm_legacy" {
       operator = "DoesNotExist"
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -58,6 +63,11 @@ prometheus.operator.podmonitors "giantswarm_legacy" {
       operator = "DoesNotExist"
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -76,6 +86,11 @@ prometheus.operator.servicemonitors "giantswarm" {
       values   = ["giantswarm"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -92,6 +107,11 @@ prometheus.operator.podmonitors "giantswarm" {
       operator = "In"
       values   = ["giantswarm"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
@@ -43,6 +43,16 @@ prometheus.operator.servicemonitors "giantswarm_legacy" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -68,6 +78,16 @@ prometheus.operator.podmonitors "giantswarm_legacy" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -91,6 +111,16 @@ prometheus.operator.servicemonitors "giantswarm" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -112,6 +142,16 @@ prometheus.operator.podmonitors "giantswarm" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
@@ -49,6 +49,11 @@ prometheus.operator.servicemonitors "giantswarm_legacy" {
       operator = "DoesNotExist"
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -69,6 +74,11 @@ prometheus.operator.podmonitors "giantswarm_legacy" {
       operator = "DoesNotExist"
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -87,6 +97,11 @@ prometheus.operator.servicemonitors "giantswarm" {
       values   = ["giantswarm"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -103,6 +118,11 @@ prometheus.operator.podmonitors "giantswarm" {
       operator = "In"
       values   = ["giantswarm"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
@@ -54,6 +54,16 @@ prometheus.operator.servicemonitors "giantswarm_legacy" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -79,6 +89,16 @@ prometheus.operator.podmonitors "giantswarm_legacy" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -102,6 +122,16 @@ prometheus.operator.servicemonitors "giantswarm" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -123,6 +153,16 @@ prometheus.operator.podmonitors "giantswarm" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.170.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.170.mc.river
@@ -25,6 +25,16 @@ prometheus.operator.servicemonitors "tenant1" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -46,6 +56,16 @@ prometheus.operator.podmonitors "tenant1" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -112,6 +132,16 @@ prometheus.operator.servicemonitors "tenant2" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -133,6 +163,16 @@ prometheus.operator.podmonitors "tenant2" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.170.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.170.mc.river
@@ -20,6 +20,11 @@ prometheus.operator.servicemonitors "tenant1" {
       values   = ["tenant1"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -36,6 +41,11 @@ prometheus.operator.podmonitors "tenant1" {
       operator = "In"
       values   = ["tenant1"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -97,6 +107,11 @@ prometheus.operator.servicemonitors "tenant2" {
       values   = ["tenant2"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -113,6 +128,11 @@ prometheus.operator.podmonitors "tenant2" {
       operator = "In"
       values   = ["tenant2"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.190.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.190.mc.river
@@ -57,6 +57,16 @@ prometheus.operator.servicemonitors "tenant1" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -78,6 +88,16 @@ prometheus.operator.podmonitors "tenant1" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -144,6 +164,16 @@ prometheus.operator.servicemonitors "tenant2" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -165,6 +195,16 @@ prometheus.operator.podmonitors "tenant2" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.190.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.190.mc.river
@@ -52,6 +52,11 @@ prometheus.operator.servicemonitors "tenant1" {
       values   = ["tenant1"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -68,6 +73,11 @@ prometheus.operator.podmonitors "tenant1" {
       operator = "In"
       values   = ["tenant1"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -129,6 +139,11 @@ prometheus.operator.servicemonitors "tenant2" {
       values   = ["tenant2"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -145,6 +160,11 @@ prometheus.operator.podmonitors "tenant2" {
       operator = "In"
       values   = ["tenant2"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
@@ -57,6 +57,16 @@ prometheus.operator.servicemonitors "tenant1" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -78,6 +88,16 @@ prometheus.operator.podmonitors "tenant1" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -144,6 +164,16 @@ prometheus.operator.servicemonitors "tenant2" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -165,6 +195,16 @@ prometheus.operator.podmonitors "tenant2" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
@@ -52,6 +52,11 @@ prometheus.operator.servicemonitors "tenant1" {
       values   = ["tenant1"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -68,6 +73,11 @@ prometheus.operator.podmonitors "tenant1" {
       operator = "In"
       values   = ["tenant1"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -129,6 +139,11 @@ prometheus.operator.servicemonitors "tenant2" {
       values   = ["tenant2"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -145,6 +160,11 @@ prometheus.operator.podmonitors "tenant2" {
       operator = "In"
       values   = ["tenant2"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
@@ -74,6 +74,11 @@ prometheus.operator.servicemonitors "tenant1" {
       values   = ["tenant1"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -90,6 +95,11 @@ prometheus.operator.podmonitors "tenant1" {
       operator = "In"
       values   = ["tenant1"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -151,6 +161,11 @@ prometheus.operator.servicemonitors "tenant2" {
       values   = ["tenant2"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -167,6 +182,11 @@ prometheus.operator.podmonitors "tenant2" {
       operator = "In"
       values   = ["tenant2"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
@@ -79,6 +79,16 @@ prometheus.operator.servicemonitors "tenant1" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -100,6 +110,16 @@ prometheus.operator.podmonitors "tenant1" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"
@@ -166,6 +186,16 @@ prometheus.operator.servicemonitors "tenant2" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -187,6 +217,16 @@ prometheus.operator.podmonitors "tenant2" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
@@ -41,6 +41,16 @@ prometheus.operator.servicemonitors "tenant1" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -62,6 +72,16 @@ prometheus.operator.podmonitors "tenant1" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
@@ -36,6 +36,11 @@ prometheus.operator.servicemonitors "tenant1" {
       values   = ["tenant1"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -52,6 +57,11 @@ prometheus.operator.podmonitors "tenant1" {
       operator = "In"
       values   = ["tenant1"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
@@ -47,6 +47,11 @@ prometheus.operator.servicemonitors "tenant1" {
       values   = ["tenant1"]
     }
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -63,6 +68,11 @@ prometheus.operator.podmonitors "tenant1" {
       operator = "In"
       values   = ["tenant1"]
     }
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
@@ -52,6 +52,16 @@ prometheus.operator.servicemonitors "tenant1" {
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
   }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
+  }
   scrape {
     default_scrape_interval = "60s"
   }
@@ -73,6 +83,16 @@ prometheus.operator.podmonitors "tenant1" {
     action = "replace"
     target_label = "team"
     source_labels = ["__meta_kubernetes_pod_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_endpoints_label_application_giantswarm_io_team"]
+  }
+  rule {
+    action = "replace"
+    target_label = "team"
+    source_labels = ["__meta_kubernetes_service_label_application_giantswarm_io_team"]
   }
   scrape {
     default_scrape_interval = "60s"


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/32792

This PR adds the `team` label to **all** metrics by transferring the `application.giantswarm.io/team` label from the pod into its metrics. I used a relabel rule rather than the ServiceMonitor.targetLabels because this felt easier than adding targetLabels field to all ServiceMonitors CRs

This example show the new team label added onto metrics (only using 2 metrics for the sake of readability)
![image](https://github.com/user-attachments/assets/f114b8a7-3823-45aa-98d4-3d467b581a2e)
