### PR TITLE
fix alloy metrics image templating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Alloy image templating when the alloy app is running the latest version.
+
 ## [0.32.0] - 2025-06-02
 
 ### Changed

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -87,10 +87,10 @@ alloy:
               - alloy
           topologyKey: kubernetes.io/hostname
         weight: 50
+  {{- if .AlloyImageTag }}
   image:
-    {{- if .AlloyImageTag }}
     tag: {{ .AlloyImageTag }}
-    {{- end }}
+  {{- end }}
 {{- if .IsSupportingVPA }}
 # We decided to configure the alloy-metrics vertical pod autoscaler as such after some investigation done https://github.com/giantswarm/giantswarm/issues/32655#issuecomment-2729636063
 verticalPodAutoscaler:


### PR DESCRIPTION
### What this PR does / why we need it

This pull request addresses a bug fix and a minor template adjustment related to Alloy image templating which causes the current release tests to fail. This happens because alloy app >= 0.10.0 is now configured with `image: null`. Helm then goes back to the default value of grafana/alloy which does not exist in our registries so the pods are stuck in CrashloopBackOff

![image](https://github.com/user-attachments/assets/6f0151f8-d088-4bb2-aefe-87b719c6cf45)


### Bug Fixes:
* Updated the `CHANGELOG.md` file to include a note about fixing Alloy image templating when the Alloy app is running the latest version.

### Template Adjustments:
* Modified the `monitoring-config.yaml.template` file to ensure the `image` tag is properly set when `AlloyImageTag` is defined.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
