### PR TITLE
alertmanager: add new inhibition for when metrics are broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Alertmanager inhibition rule `cancel_if_metrics_broken`
+
 ### Changed
 
 - Comprehensive Helm chart support for webhook configuration:

--- a/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
+++ b/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
@@ -289,6 +289,12 @@ inhibit_rules:
     - cancel_if_monitoring_agent_down=true
   equal: [cluster_id]
 
+# When metrics are unreliable (mimir broken)
+- source_matchers:
+    - inhibit_metrics_broken=true
+  target_matchers:
+    - cancel_if_metrics_broken=true
+
 # Source: https://github.com/giantswarm/prometheus-rules/blob/main/helm/prometheus-rules/templates/kaas/tenet/alerting-rules/inhibit.nodes.rules.yml
 - source_matchers:
     - node_not_ready=true


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/33527

Add a new inhibition rule so we can skip some alerts when metrics are unreliable (happens when mimir is broken).


### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
