### PR TITLE
update tenant validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Enhanced TenantID validation for Alloy compatibility**: Updated GrafanaOrganization CRD validation to ensure tenant names are compatible with Alloy component naming requirements:
+  - Changed validation pattern from `^[a-zA-Z0-9!._*'()-]+$` to `^[a-zA-Z_][a-zA-Z0-9_]{0,149}$` to follow Alloy identifier rules (must start with letter or underscore, only alphanumeric and underscores allowed)
+  - Simplified webhook validation architecture by moving structural validation (pattern, length) to CRD level and keeping only business logic validation (forbidden values, duplicates) in webhook
+  - Updated forbidden values list to only include `__mimir_cluster` as other previously forbidden values (`.`, `..`) are now caught by the CRD pattern
+  - Converted webhook tests to integration-only tests using `k8sClient.Create()` for more realistic validation pipeline testing
+  - Updated documentation and comments to reflect Alloy component naming constraints and 150-character limit
+
 ## [0.33.0] - 2025-06-16
 
 ### Added

--- a/api/v1alpha1/grafanaorganization_types.go
+++ b/api/v1alpha1/grafanaorganization_types.go
@@ -27,11 +27,14 @@ type GrafanaOrganizationSpec struct {
 	Tenants []TenantID `json:"tenants"`
 }
 
-// TenantID is a unique identifier for a tenant. Must follow Grafana Mimir tenant ID restrictions.
+// TenantID is a unique identifier for a tenant. Must follow both Grafana Mimir tenant ID restrictions
+// and Alloy component naming restrictions.
 // See: https://grafana.com/docs/mimir/latest/configure/about-tenant-ids/
-// Allowed characters: alphanumeric (a-z, A-Z, 0-9) and special characters (!, -, _, ., *, ', (, ))
-// Forbidden values: ".", "..", "__mimir_cluster" (enforced by validating webhook)
-// +kubebuilder:validation:Pattern="^[a-zA-Z0-9!._*'()-]+$"
+// See: https://grafana.com/docs/alloy/latest/get-started/configuration-syntax/syntax/#identifiers
+// Allowed characters: alphanumeric (a-z, A-Z, 0-9) and underscore (_)
+// Must start with a letter or underscore, max 150 characters (Mimir tenant limit)
+// Forbidden value: "__mimir_cluster" (enforced by validating webhook)
+// +kubebuilder:validation:Pattern="^[a-zA-Z_][a-zA-Z0-9_]{0,149}$"
 // +kubebuilder:validation:MinLength=1
 // +kubebuilder:validation:MaxLength=150
 type TenantID string

--- a/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
+++ b/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
@@ -87,13 +87,16 @@ spec:
                 - giantswarm
                 items:
                   description: |-
-                    TenantID is a unique identifier for a tenant. Must follow Grafana Mimir tenant ID restrictions.
+                    TenantID is a unique identifier for a tenant. Must follow both Grafana Mimir tenant ID restrictions
+                    and Alloy component naming restrictions.
                     See: https://grafana.com/docs/mimir/latest/configure/about-tenant-ids/
-                    Allowed characters: alphanumeric (a-z, A-Z, 0-9) and special characters (!, -, _, ., *, ', (, ))
-                    Forbidden values: ".", "..", "__mimir_cluster" (enforced by validating webhook)
+                    See: https://grafana.com/docs/alloy/latest/get-started/configuration-syntax/syntax/#identifiers
+                    Allowed characters: alphanumeric (a-z, A-Z, 0-9) and underscore (_)
+                    Must start with a letter or underscore, max 150 characters (Mimir tenant limit)
+                    Forbidden value: "__mimir_cluster" (enforced by validating webhook)
                   maxLength: 150
                   minLength: 1
-                  pattern: ^[a-zA-Z0-9!._*'()-]+$
+                  pattern: ^[a-zA-Z_][a-zA-Z0-9_]{0,149}$
                   type: string
                 type: array
             required:

--- a/internal/webhook/v1/alertmanager_config_secret_webhook_test.go
+++ b/internal/webhook/v1/alertmanager_config_secret_webhook_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Secret Webhook", func() {
 				Namespace: "test-namespace",
 				Labels: map[string]string{
 					"observability.giantswarm.io/kind":   "alertmanager-config",
-					"observability.giantswarm.io/tenant": "test-tenant",
+					"observability.giantswarm.io/tenant": "test_tenant",
 				},
 			},
 			Data: map[string][]byte{
@@ -132,7 +132,7 @@ receivers:
 				},
 				Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
 					DisplayName: "Test Organization",
-					Tenants:     []observabilityv1alpha1.TenantID{"test-tenant"},
+					Tenants:     []observabilityv1alpha1.TenantID{"test_tenant"},
 					RBAC: &observabilityv1alpha1.RBAC{
 						Admins: []string{"admin-org"},
 					},
@@ -165,7 +165,7 @@ receivers:
 					Namespace: "test-namespace",
 					Labels: map[string]string{
 						"observability.giantswarm.io/kind":   "alertmanager-config",
-						"observability.giantswarm.io/tenant": "test-tenant",
+						"observability.giantswarm.io/tenant": "test_tenant",
 					},
 				},
 				Data: map[string][]byte{

--- a/internal/webhook/v1/grafanaorganization_webhook_test.go
+++ b/internal/webhook/v1/grafanaorganization_webhook_test.go
@@ -28,170 +28,242 @@ import (
 	observabilityv1alpha1 "github.com/giantswarm/observability-operator/api/v1alpha1"
 )
 
-var _ = Describe("GrafanaOrganization Webhook", func() {
-	var (
-		ctx       context.Context
-		obj       *observabilityv1alpha1.GrafanaOrganization
-		oldObj    *observabilityv1alpha1.GrafanaOrganization
-		validator GrafanaOrganizationValidator
-	)
+var _ = Describe("GrafanaOrganization Validation", func() {
+	var ctx context.Context
 
 	BeforeEach(func() {
 		ctx = context.Background()
-		obj = &observabilityv1alpha1.GrafanaOrganization{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-org",
-			},
-			Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
-				DisplayName: "Test Organization",
-				Tenants:     []observabilityv1alpha1.TenantID{"test-tenant"},
-			},
-		}
-		oldObj = &observabilityv1alpha1.GrafanaOrganization{}
-		validator = GrafanaOrganizationValidator{}
-		Expect(validator).NotTo(BeNil(), "Expected validator to be initialized")
-		Expect(oldObj).NotTo(BeNil(), "Expected oldObj to be initialized")
-		Expect(obj).NotTo(BeNil(), "Expected obj to be initialized")
 	})
 
-	AfterEach(func() {
-		// Cleanup if needed
-	})
+	Context("When testing full validation pipeline (CRD + Webhook)", func() {
+		It("Should reject tenant IDs with invalid patterns (CRD validation)", func() {
+			testCases := []struct {
+				name     string
+				tenantID string
+				reason   string
+			}{
+				{"hyphens", "tenant-with-hyphens", "hyphens not allowed in Alloy identifiers"},
+				{"dots", "tenant.with.dots", "dots not allowed in Alloy identifiers"},
+				{"spaces", "tenant with space", "spaces not allowed"},
+				{"starts_with_number", "123tenant", "must start with letter or underscore"},
+				{"special_chars", "tenant@symbol", "special characters not allowed"},
+			}
 
-	Context("When creating or updating GrafanaOrganization under Validating Webhook", func() {
-		It("Should reject empty tenant IDs", func() {
+			for _, tc := range testCases {
+				By("Testing " + tc.name + ": " + tc.reason)
+				grafanaOrg := &observabilityv1alpha1.GrafanaOrganization{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-org-invalid-" + tc.name,
+					},
+					Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
+						DisplayName: "Test Organization",
+						Tenants:     []observabilityv1alpha1.TenantID{observabilityv1alpha1.TenantID(tc.tenantID)},
+						RBAC: &observabilityv1alpha1.RBAC{
+							Admins: []string{"admin-org"},
+						},
+					},
+				}
+
+				err := k8sClient.Create(ctx, grafanaOrg)
+				Expect(err).To(HaveOccurred(), "Tenant ID %q should be rejected by CRD validation", tc.tenantID)
+				Expect(err.Error()).To(ContainSubstring("should match"), "Error should mention pattern validation")
+			}
+		})
+
+		It("Should reject tenant IDs with invalid lengths (CRD validation)", func() {
 			By("Testing empty tenant ID")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{""}
-			_, err := validator.ValidateCreate(ctx, obj)
+			grafanaOrg := &observabilityv1alpha1.GrafanaOrganization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-org-empty",
+				},
+				Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
+					DisplayName: "Test Organization",
+					Tenants:     []observabilityv1alpha1.TenantID{""},
+					RBAC: &observabilityv1alpha1.RBAC{
+						Admins: []string{"admin-org"},
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, grafanaOrg)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tenant ID cannot be empty"))
+			Expect(err.Error()).To(ContainSubstring("should be at least 1 chars long"))
+
+			By("Testing tenant ID that's too long (151 chars)")
+			tooLongTenant := "a" + strings.Repeat("b", 150) // 151 characters total
+			grafanaOrg.ObjectMeta.Name = "test-org-too-long"
+			grafanaOrg.Spec.Tenants = []observabilityv1alpha1.TenantID{observabilityv1alpha1.TenantID(tooLongTenant)}
+
+			err = k8sClient.Create(ctx, grafanaOrg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("Too long"))
 		})
 
-		It("Should reject duplicate tenant IDs", func() {
+		It("Should reject forbidden tenant values (Webhook validation)", func() {
+			By("Testing __mimir_cluster (passes CRD pattern but forbidden by Mimir)")
+			grafanaOrg := &observabilityv1alpha1.GrafanaOrganization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-org-forbidden",
+				},
+				Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
+					DisplayName: "Test Organization",
+					Tenants:     []observabilityv1alpha1.TenantID{"__mimir_cluster"},
+					RBAC: &observabilityv1alpha1.RBAC{
+						Admins: []string{"admin-org"},
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, grafanaOrg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("__mimir_cluster\" is not allowed"))
+		})
+
+		It("Should reject duplicate tenant IDs (Webhook validation)", func() {
 			By("Testing duplicate tenant IDs")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"tenant1", "tenant2", "tenant1"}
-			_, err := validator.ValidateCreate(ctx, obj)
+			grafanaOrg := &observabilityv1alpha1.GrafanaOrganization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-org-duplicates",
+				},
+				Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
+					DisplayName: "Test Organization",
+					Tenants:     []observabilityv1alpha1.TenantID{"valid_tenant", "valid_tenant"},
+					RBAC: &observabilityv1alpha1.RBAC{
+						Admins: []string{"admin-org"},
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, grafanaOrg)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("duplicate tenant ID \"tenant1\" found"))
+			Expect(err.Error()).To(ContainSubstring("duplicate tenant ID"))
 		})
 
-		It("Should reject tenant IDs with leading/trailing whitespace", func() {
-			By("Testing tenant ID with leading whitespace")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{" tenant-with-space"}
-			_, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("contains leading or trailing whitespace"))
+		It("Should allow valid tenant IDs", func() {
+			testCases := []struct {
+				name    string
+				tenants []string
+				reason  string
+			}{
+				{"single_tenant", []string{"tenant123"}, "basic alphanumeric"},
+				{"underscores", []string{"tenant_with_underscore"}, "underscores allowed"},
+				{"starts_with_underscore", []string{"_starts_with_underscore"}, "can start with underscore"},
+				{"mixed_case", []string{"MixedCase123"}, "mixed case allowed"},
+				{"long_name", []string{"a" + strings.Repeat("b", 149)}, "150 characters (max length)"},
+				{"multiple_valid", []string{"prod_env", "staging_env"}, "multiple unique tenants"},
+			}
 
-			By("Testing tenant ID with trailing whitespace")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"tenant-with-space "}
-			_, err = validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("contains leading or trailing whitespace"))
+			for i, tc := range testCases {
+				By("Testing " + tc.name + ": " + tc.reason)
+				tenantIDs := make([]observabilityv1alpha1.TenantID, len(tc.tenants))
+				for j, t := range tc.tenants {
+					tenantIDs[j] = observabilityv1alpha1.TenantID(t)
+				}
+
+				grafanaOrg := &observabilityv1alpha1.GrafanaOrganization{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-org-valid-" + strings.ReplaceAll(tc.name, "_", "-") + "-" + string(rune(i+97)), // Use lowercase letters starting from 'a'
+					},
+					Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
+						DisplayName: "Test Organization",
+						Tenants:     tenantIDs,
+						RBAC: &observabilityv1alpha1.RBAC{
+							Admins: []string{"admin-org"},
+						},
+					},
+				}
+
+				err := k8sClient.Create(ctx, grafanaOrg)
+				Expect(err).NotTo(HaveOccurred(), "Valid tenants %v should be accepted", tc.tenants)
+
+				// Clean up immediately
+				_ = k8sClient.Delete(ctx, grafanaOrg)
+			}
 		})
 
-		It("Should allow valid tenant IDs with various allowed characters", func() {
-			By("Testing alphanumeric characters")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"tenant123", "TENANT456", "MixedCase789"}
-			_, err := validator.ValidateCreate(ctx, obj)
+		It("Should allow updates with valid changes", func() {
+			By("Creating a valid GrafanaOrganization")
+			grafanaOrg := &observabilityv1alpha1.GrafanaOrganization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-org-update",
+				},
+				Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
+					DisplayName: "Test Organization",
+					Tenants:     []observabilityv1alpha1.TenantID{"initial_tenant"},
+					RBAC: &observabilityv1alpha1.RBAC{
+						Admins: []string{"admin-org"},
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, grafanaOrg)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Testing special characters")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"tenant-with-dash", "tenant_with_underscore", "tenant.with.dots"}
-			_, err = validator.ValidateCreate(ctx, obj)
+			defer func() {
+				_ = k8sClient.Delete(ctx, grafanaOrg)
+			}()
+
+			By("Updating with valid tenant changes")
+			grafanaOrg.Spec.Tenants = []observabilityv1alpha1.TenantID{"updated_tenant", "another_tenant"}
+			err = k8sClient.Update(ctx, grafanaOrg)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Testing more special characters")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"tenant!exclamation", "tenant*asterisk", "tenant'quote", "tenant(paren)", "tenant)paren"}
-			_, err = validator.ValidateCreate(ctx, obj)
-			Expect(err).NotTo(HaveOccurred())
-		})
-
-		It("Should reject forbidden tenant ID values", func() {
-			By("Testing single dot")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"."}
-			_, err := validator.ValidateCreate(ctx, obj)
+			By("Attempting update with invalid tenant (should fail)")
+			grafanaOrg.Spec.Tenants = []observabilityv1alpha1.TenantID{"__mimir_cluster"}
+			err = k8sClient.Update(ctx, grafanaOrg)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tenant ID \".\" is not allowed"))
-
-			By("Testing double dot")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{".."}
-			_, err = validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tenant ID \"..\" is not allowed"))
-
-			By("Testing mimir cluster reserved name")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"__mimir_cluster"}
-			_, err = validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tenant ID \"__mimir_cluster\" is not allowed"))
-		})
-
-		It("Should allow valid tenant IDs mixed with forbidden ones and reject appropriately", func() {
-			By("Testing a mix where one is forbidden")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"valid-tenant", "."}
-			_, err := validator.ValidateCreate(ctx, obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tenant ID \".\" is not allowed"))
-		})
-
-		It("Should validate on updates as well as creates", func() {
-			By("Testing update with valid tenant IDs")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{"valid-tenant-update"}
-			_, err := validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Testing update with forbidden tenant ID")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{".."}
-			_, err = validator.ValidateUpdate(ctx, oldObj, obj)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tenant ID \"..\" is not allowed"))
+			Expect(err.Error()).To(ContainSubstring("__mimir_cluster\" is not allowed"))
 		})
 
 		It("Should allow deletion without validation", func() {
-			By("Testing delete operation")
-			_, err := validator.ValidateDelete(ctx, obj)
-			Expect(err).NotTo(HaveOccurred())
-		})
+			By("Creating and then deleting a GrafanaOrganization")
+			grafanaOrg := &observabilityv1alpha1.GrafanaOrganization{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-org-delete",
+				},
+				Spec: observabilityv1alpha1.GrafanaOrganizationSpec{
+					DisplayName: "Test Organization",
+					Tenants:     []observabilityv1alpha1.TenantID{"delete_test_tenant"},
+					RBAC: &observabilityv1alpha1.RBAC{
+						Admins: []string{"admin-org"},
+					},
+				},
+			}
 
-		It("Should handle edge cases gracefully", func() {
-			By("Testing empty tenant list")
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{}
-			_, err := validator.ValidateCreate(ctx, obj)
+			err := k8sClient.Create(ctx, grafanaOrg)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Testing long valid tenant ID (up to 150 chars)")
-			longTenantStr := strings.Repeat("a", 150) // 150 chars total
-			longTenant := observabilityv1alpha1.TenantID(longTenantStr)
-			obj.Spec.Tenants = []observabilityv1alpha1.TenantID{longTenant}
-			_, err = validator.ValidateCreate(ctx, obj)
+			err = k8sClient.Delete(ctx, grafanaOrg)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 
-	Context("When testing TenantID pattern validation (simulating kubebuilder validation)", func() {
-		// Helper function to simulate the kubebuilder pattern validation
+	Context("When demonstrating what CRD pattern validation covers", func() {
+		// Helper function to simulate the kubebuilder pattern validation for Alloy-compatible names
 		isValidTenantIDPattern := func(tenantID string) bool {
 			if len(tenantID) == 0 || len(tenantID) > 150 {
 				return false
 			}
 
-			for _, r := range tenantID {
-				// Alphanumeric characters
-				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
-					continue
-				}
-				// Special characters allowed by our pattern: ^[a-zA-Z0-9!._*'()-]+$
-				switch r {
-				case '!', '.', '_', '*', '\'', '(', ')', '-':
-					continue
-				default:
+			// Must start with a letter or underscore (following Alloy identifier rules)
+			if len(tenantID) > 0 {
+				first := tenantID[0]
+				if !((first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || first == '_') {
 					return false
 				}
+			}
+
+			for _, r := range tenantID {
+				// Only alphanumeric characters and underscore allowed (no hyphens in Alloy)
+				if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+					continue
+				}
+				return false
 			}
 			return true
 		}
 
-		It("Should allow all valid TenantID patterns according to Grafana Mimir spec", func() {
+		It("Should show which patterns are valid according to CRD validation", func() {
 			validTenantIDs := []struct {
 				id          string
 				description string
@@ -199,59 +271,34 @@ var _ = Describe("GrafanaOrganization Webhook", func() {
 				{"tenant123", "lowercase alphanumeric"},
 				{"TENANT123", "uppercase alphanumeric"},
 				{"TeNaNt123", "mixed case alphanumeric"},
-				{"tenant-with-dash", "contains dash character"},
 				{"tenant_with_underscore", "contains underscore character"},
-				{"tenant.with.dots", "contains dot character"},
-				{"tenant!exclamation", "contains exclamation character"},
-				{"tenant*asterisk", "contains asterisk character"},
-				{"tenant'quote", "contains single quote character"},
-				{"tenant(with)parentheses", "contains parentheses characters"},
-				{"tenant!-_.*'()", "contains all allowed special characters"},
+				{"_starts_with_underscore", "starts with underscore"},
 				{"giantswarm", "example from kubebuilder annotation"},
-				{"my-tenant-123", "typical tenant name with dash and numbers"},
+				{"my_tenant_123", "typical tenant name with underscore and numbers"},
 				{"PROD_ENVIRONMENT", "uppercase with underscore"},
-				{"dev.staging.test", "dots for environment separation"},
-				{strings.Repeat("a", 150), "150 characters long (max allowed)"},
+				{"dev_staging_test", "underscores for environment separation"},
+				{"a" + strings.Repeat("b", 149), "150 characters long (max allowed)"},
 			}
 
 			for _, tc := range validTenantIDs {
 				By("Testing valid tenant ID: " + tc.description)
 				Expect(isValidTenantIDPattern(tc.id)).To(BeTrue(),
 					"TenantID %q should be valid for %s", tc.id, tc.description)
-
-				// Also test with the webhook validator (should pass webhook validation too)
-				obj.Spec.Tenants = []observabilityv1alpha1.TenantID{observabilityv1alpha1.TenantID(tc.id)}
-				_, err := validator.ValidateCreate(ctx, obj)
-				Expect(err).NotTo(HaveOccurred(),
-					"TenantID %q should pass webhook validation for %s", tc.id, tc.description)
 			}
 		})
 
-		It("Should reject invalid TenantID patterns that would fail kubebuilder validation", func() {
+		It("Should show which patterns are invalid according to CRD validation", func() {
 			invalidTenantIDs := []struct {
 				id          string
 				description string
 			}{
-				{"tenant/with/slash", "contains forward slash (not allowed)"},
-				{"tenant\\with\\backslash", "contains backward slash (not allowed)"},
+				{"1tenant", "starts with number (invalid Alloy identifier)"},
+				{"123abc", "starts with number (invalid Alloy identifier)"},
+				{"tenant-with-dash", "contains dash (invalid Alloy identifier)"},
+				{"tenant.with.dots", "contains dots (invalid Alloy identifier)"},
 				{"tenant with space", "contains space (not allowed)"},
 				{"tenant@symbol", "contains @ symbol (not allowed)"},
-				{"tenant#hash", "contains # symbol (not allowed)"},
-				{"tenant$dollar", "contains $ symbol (not allowed)"},
-				{"tenant%percent", "contains % symbol (not allowed)"},
-				{"tenant^caret", "contains ^ symbol (not allowed)"},
-				{"tenant&ampersand", "contains & symbol (not allowed)"},
-				{"tenant=equals", "contains = symbol (not allowed)"},
-				{"tenant+plus", "contains + symbol (not allowed)"},
-				{"tenant[bracket]", "contains square brackets (not allowed)"},
-				{"tenant{brace}", "contains curly braces (not allowed)"},
-				{"tenant|pipe", "contains pipe symbol (not allowed)"},
-				{"tenant:colon", "contains colon (not allowed)"},
-				{"tenant;semicolon", "contains semicolon (not allowed)"},
-				{"tenant\"quote", "contains double quote (not allowed)"},
-				{"tenant<less>", "contains angle brackets (not allowed)"},
-				{"tenant?question", "contains question mark (not allowed)"},
-				{"tenant,comma", "contains comma (not allowed)"},
+				{"tenant!exclamation", "contains special characters (not allowed)"},
 				{"", "empty string (below minimum length)"},
 				{strings.Repeat("a", 151), "151 characters long (exceeds max length)"},
 			}
@@ -263,7 +310,7 @@ var _ = Describe("GrafanaOrganization Webhook", func() {
 			}
 		})
 
-		It("Should correctly validate length constraints", func() {
+		It("Should validate length constraints", func() {
 			By("Testing minimum length boundary")
 			Expect(isValidTenantIDPattern("a")).To(BeTrue(), "Single character should be valid")
 


### PR DESCRIPTION
### What this PR does / why we need it

Alloy identifiers are more restrictive than actual tenant names but we use the tenant names in alloy configurations so let's align with https://grafana.com/docs/alloy/latest/get-started/configuration-syntax/syntax/#identifiers

This relates to https://github.com/giantswarm/docs/pull/2631

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
