### PR TITLE
new cancel_if_cluster_broken inhibition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added Kubernetes validating webhook to validate dashboard ConfigMaps with `app.giantswarm.io/kind=dashboard` label.
   - Includes comprehensive test coverage, Helm chart integration with `webhook.validatingWebhooks.dashboardConfigMap.enabled` configuration, and kubebuilder scaffolding.
   - Webhook is ready for business logic implementation to validate dashboard JSON structure and required fields.
+- New `cancel_if_cluster_broken` alertmanager inhibition.
 
 ## [0.33.1] - 2025-06-19
 

--- a/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
+++ b/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
@@ -289,6 +289,13 @@ inhibit_rules:
     - cancel_if_monitoring_agent_down=true
   equal: [cluster_id]
 
+# When a cluster looks broken
+- source_matchers:
+    - inhibit_cluster_broken=true
+  target_matchers:
+    - cancel_if_cluster_broken=true
+  equal: [cluster_id]
+
 # When metrics are unreliable (mimir broken)
 - source_matchers:
     - inhibit_metrics_broken=true


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/prometheus-rules/pull/1657
When we have an alert that detects a cluster is broken, we want to cancel some alerts.
This is the purpose of this new `cancel_if_cluster_broken` inhibition.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
