### PR TITLE
alloy-metrics: tune VPA and RAM limits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Alloy-metrics RAM reservations / limits tuning.
+
 ## [0.34.0] - 2025-07-02
 
 ### Added

--- a/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
+++ b/pkg/monitoring/alloy/templates/monitoring-config.yaml.template
@@ -55,7 +55,7 @@ alloy:
     resources:
       limits:
         cpu: 100m
-        memory: 1024Mi
+        memory: 768Mi
       requests:
         cpu: 25m
         memory: 512Mi
@@ -104,6 +104,7 @@ verticalPodAutoscaler:
       controlledValues: "RequestsAndLimits"
       maxAllowed: 
         cpu: 500m
+        memory: 10Gi
       minAllowed:
         cpu: 25m
         memory: 512Mi


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/33858

Try to workaround greedy VPA by limiting it.
As alloy-metrics also scales horizontally based on number of ingested metrics, this limit should be ok whatever the WC size.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
