### PR TITLE
remove crd to avoid conflicts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- CRDs are managed via MCB so we need to clean them up from the operator.
+
 ## [0.35.0] - 2025-07-10
 
 ### Changed

--- a/helm/observability-operator/templates/crds/observability.giantswarm.io_grafanaorganizations.yaml
+++ b/helm/observability-operator/templates/crds/observability.giantswarm.io_grafanaorganizations.yaml
@@ -1,1 +1,0 @@
-../../../../config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml


### PR DESCRIPTION
### What this PR does / why we need it


When creating ferret, the operator app was failing because it could not install the CRDs (setting label ownership) because they are already installed via flux. They need to be removed from the mc:

https://gigantic.slack.com/archives/C01176DKNP4/p1752756059154689

This might also fix https://github.com/giantswarm/giantswarm/issues/33712

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
