### PR TITLE
Remove git checkout warning

### DIFF
--- a/hack/bin/validate-alertmanager-config.sh
+++ b/hack/bin/validate-alertmanager-config.sh
@@ -54,7 +54,7 @@ git clone https://github.com/grafana/prometheus-alertmanager.git "$REPO_DIR"
 cd "$REPO_DIR"
 
 echo "Checking out commit: $ALERTMANAGER_COMMIT"
-git checkout "$ALERTMANAGER_COMMIT"
+git -c advice.detachedHead=false checkout "$ALERTMANAGER_COMMIT"
 
 # Show some info about the current state
 echo "✓ Repository ready for go run"


### PR DESCRIPTION
Remove the git checkout warning on detached HEAD state in the `validate-alertmanager-config.sh` script.

### Before

```
Checking out commit: fa9fa7096626
Note: switching to 'fa9fa7096626'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

HEAD is now at fa9fa709 Merge pull request #99 from grobinson-grafana/revert-94-grobinson/fork-fix-inhibit-rules-equal-utf8
✓ Repository ready for go run
Current commit info:
  Commit: fa9fa70966264f25e09bfc8a2e35a34f24613168
  Short commit: fa9fa709
Go environment:
  Go version: go version go1.24.2 linux/amd64
  Module path: /tmp/validate-alertmanager-config.JGO656/prometheus-alertmanager
✓ Go module ready: module github.com/prometheus/alertmanager

=== Rendering Helm Chart ===
```

### After

```
Checking out commit: fa9fa7096626
HEAD is now at fa9fa709 Merge pull request #99 from grobinson-grafana/revert-94-grobinson/fork-fix-inhibit-rules-equal-utf8
✓ Repository ready for go run
Current commit info:
  Commit: fa9fa70966264f25e09bfc8a2e35a34f24613168
  Short commit: fa9fa709
Go environment:
  Go version: go version go1.24.2 linux/amd64
  Module path: /tmp/validate-alertmanager-config.noyQWI/prometheus-alertmanager
✓ Go module ready: module github.com/prometheus/alertmanager

=== Rendering Helm Chart ===
```