### PR TITLE
Upgrade prometheus-alertmanager dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `github.com/grafana/prometheus-alertmanager` dependency after the new mimir release.
+
 ## [0.38.0] - 2025-08-25
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -134,5 +134,5 @@ replace (
 	github.com/hashicorp/go-retryablehttp => github.com/hashicorp/go-retryablehttp v0.7.8
 	// Replacing prometheus/alertmanager with grafana mimir fork to support the same alertmanager configuration options.
 	// Renovate will update this to the latest version of the fork whenever a new version of Mimir is available.
-	github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20250305143719-fa9fa7096626
+	github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20250620093340-be61a673dee6
 )

--- a/go.sum
+++ b/go.sum
@@ -226,8 +226,8 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250821140309-7f4c35f8ae28 h1:gYaJpohvgVSUPoP85lHIIbzxL5onX4i/8MMPdJLraqg=
 github.com/grafana/grafana-openapi-client-go v0.0.0-20250821140309-7f4c35f8ae28/go.mod h1:AOzHLStinAJHJmcih1eEbIRImxpT6enYUsZLnnOvhbo=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250305143719-fa9fa7096626 h1:QsMYtDseSPq8hXvoNtA64unFiawJaE5kryizcMsVZWg=
-github.com/grafana/prometheus-alertmanager v0.25.1-0.20250305143719-fa9fa7096626/go.mod h1:FGdGvhI40Dq+CTQaSzK9evuve774cgOUdGfVO04OXkw=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20250620093340-be61a673dee6 h1:oJnbhG6ZNy10AjsgNeAtAKeGHogIGOMfAsBH6fYYa5M=
+github.com/grafana/prometheus-alertmanager v0.25.1-0.20250620093340-be61a673dee6/go.mod h1:O/QP1BCm0HHIzbKvgMzqb5sSyH88rzkFk84F4TfJjBU=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0 h1:TmHmbvxPmaegwhDubVz0lICL0J5Ka2vwTzhoePEXsGE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0/go.mod h1:qztMSjm835F2bXf+5HKAPIS5qsmQDqZna/PgVt4rWtI=


### PR DESCRIPTION
### What this PR does / why we need it

Mimir 2.17.0 was released, so we need to sync the alertmanager dependency

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
