### PR TITLE
Fix index out of range error in Alertmanager notification template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update PagerDuty notification template, to include relevant information about the alert.
 - Upgrade `github.com/grafana/prometheus-alertmanager` dependency after the new mimir release.
 
+### Fixed
+
+- Fixed index out of range error in Alertmanager notification template
+
 ## [0.38.0] - 2025-08-25
 
 ### Added

--- a/helm/observability-operator/files/alertmanager/notification-template.tmpl
+++ b/helm/observability-operator/files/alertmanager/notification-template.tmpl
@@ -24,7 +24,7 @@
 {{- end }}
 {{ end }}
 
-{{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }}{{ if not (eq .GroupLabels.cluster_id .GroupLabels.installation) }}-{{ .GroupLabels.cluster_id }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
+{{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }}{{ if not (eq .GroupLabels.cluster_id .GroupLabels.installation) }}-{{ .GroupLabels.cluster_id }}{{ end }} - {{ .GroupLabels.alertname }}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" -}}
 {{ if (index .Alerts 0).Annotations.runbook_url -}}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/34016

This PR fixes an index out of range error that occurs when rendering the Alertmanager notification template. This might be a corner case due to my testing, but since the alertmanager is part of the group label let's use this and avoid the error.

```
ts=2025-08-26T14:57:40.603413054Z caller=dispatch.go:403 level=error component=MultiTenantAlertmanager user=giantswarm component=dispatcher insight=true component=dispatcher pipeline_time=2025-08-26T14:57:10.601455207Z aggrGroup="{}/{severity=\"page\"}:{alertname=\"test-from-golem2\", cluster_id=\"golem\", installation=\"golem\", status=\"firing\", team=\"atlas\"}" alerts=[test-from-golem2[cedc75c][resolved]] msg="Notify for alerts failed" num_alerts=1 err="pagerduty/pagerduty[0]: notify retry canceled due to unrecoverable error after 1 attempts: failed to template PagerDuty v2 message: template: :27:189: executing \"opsgenie.default.message\" at <index .Alerts.Firing 0>: error calling index: reflect: slice index out of range"
```

Tested and working. Alert are still populated with their alertname in the title: https://giantswarm.app.opsgenie.com/alert/detail/c3abfc6e-7a25-4558-a001-6be631c34f45-1756221159383/details