### PR TITLE
Add PagerDuty heartbeat route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add Alertmanager PagerDuty heartbeat route
+
 ### Changed
 
 - Update PagerDuty notification template, to include relevant information about the alert.

--- a/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
+++ b/helm/observability-operator/files/alertmanager/alertmanager.yaml.helm-template
@@ -81,6 +81,14 @@ route:
     matchers:
     - severity="page"
     continue: true
+
+  - receiver: pagerduty
+    matchers:
+    - alertname="Heartbeat"
+    continue: true
+    group_wait: 30s
+    group_interval: 30s
+    repeat_interval: 15m
 {{- end }}
 
   # Team Atlas Slack

--- a/helm/observability-operator/files/alertmanager/notification-template.tmpl
+++ b/helm/observability-operator/files/alertmanager/notification-template.tmpl
@@ -24,7 +24,7 @@
 {{- end }}
 {{ end }}
 
-{{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }}{{ if not (eq .GroupLabels.cluster_id .GroupLabels.installation) }}-{{ .GroupLabels.cluster_id }}{{ end }} - {{ index (index .Alerts.Firing 0).Labels `alertname`}}{{ end }}
+{{ define "opsgenie.default.message" }}{{ .GroupLabels.installation }}{{ if not (eq .GroupLabels.cluster_id .GroupLabels.installation) }}-{{ .GroupLabels.cluster_id }}{{ end }} - {{ .GroupLabels.alertname }}{{ end }}
 {{ define "opsgenie.default.source" }}{{ template "__alertmanager" . }}{{ end }}
 {{ define "opsgenie.default.description" -}}
 {{ if (index .Alerts 0).Annotations.runbook_url -}}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/34016

This PR adds the Alertmanager config to route heartbeat alerts to PagerDuty.

Heartbeat alerts are handled a "regular alerts" but there's a special logic builtin PagerDuty for those to fire if heartbeats are missing.
The interval are copied from our current OpsGenie heartbeat route.