### PR TITLE
enable configuration of alloy queue config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add configurable `queue_config` fields for Alloy remote write. All Alloy `queue_config` fields (`batch_send_deadline`, `capacity`, `max_backoff`, `max_samples_per_send`, `max_shards`, `min_backoff`, `min_shards`, `retry_on_http_429`, `sample_age_limit`) are now configurable via helm values and command line flags. When not configured, Alloy defaults are used.
+
 ## [0.40.0] - 2025-08-27
 
 ### Added

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -117,12 +117,63 @@ func runner() error {
 		"Configures how frequently the Write-Ahead Log (WAL) truncates segments.")
 	flag.StringVar(&conf.Monitoring.MetricsQueryURL, "monitoring-metrics-query-url", "http://mimir-gateway.mimir.svc/prometheus",
 		"URL to query for cluster metrics")
+
+	// Queue configuration flags for Alloy remote write
+	var queueBatchSendDeadline, queueMaxBackoff, queueMinBackoff, queueSampleAgeLimit string
+	var queueCapacity, queueMaxSamplesPerSend, queueMaxShards, queueMinShards int
+	var queueRetryOnHttp429 bool
+
+	flag.StringVar(&queueBatchSendDeadline, "monitoring-queue-config-batch-send-deadline", "",
+		"Maximum time samples wait in the buffer before sending (e.g., '5s'). If empty, Alloy default is used.")
+	flag.IntVar(&queueCapacity, "monitoring-queue-config-capacity", 0,
+		"Number of samples to buffer per shard. If 0, Alloy default is used.")
+	flag.StringVar(&queueMaxBackoff, "monitoring-queue-config-max-backoff", "",
+		"Maximum retry delay (e.g., '5s'). If empty, Alloy default is used.")
+	flag.IntVar(&queueMaxSamplesPerSend, "monitoring-queue-config-max-samples-per-send", 0,
+		"Maximum number of samples per send. If 0, Alloy default is used.")
+	flag.IntVar(&queueMaxShards, "monitoring-queue-config-max-shards", 0,
+		"Maximum number of concurrent shards. If 0, Alloy default is used.")
+	flag.StringVar(&queueMinBackoff, "monitoring-queue-config-min-backoff", "",
+		"Initial retry delay (e.g., '30ms'). If empty, Alloy default is used.")
+	flag.IntVar(&queueMinShards, "monitoring-queue-config-min-shards", 0,
+		"Minimum number of concurrent shards. If 0, Alloy default is used.")
+	flag.BoolVar(&queueRetryOnHttp429, "monitoring-queue-config-retry-on-http-429", true,
+		"Retry when an HTTP 429 status code is received.")
+	flag.StringVar(&queueSampleAgeLimit, "monitoring-queue-config-sample-age-limit", "",
+		"Maximum age of samples to send (e.g., '30m'). If empty, Alloy default is used.")
+
 	opts := zap.Options{
 		Development: false,
 	}
-
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
+
+	// Set queue config based on flags (only if values were provided)
+	if queueBatchSendDeadline != "" {
+		conf.Monitoring.QueueConfig.BatchSendDeadline = &queueBatchSendDeadline
+	}
+	if queueCapacity > 0 {
+		conf.Monitoring.QueueConfig.Capacity = &queueCapacity
+	}
+	if queueMaxBackoff != "" {
+		conf.Monitoring.QueueConfig.MaxBackoff = &queueMaxBackoff
+	}
+	if queueMaxSamplesPerSend > 0 {
+		conf.Monitoring.QueueConfig.MaxSamplesPerSend = &queueMaxSamplesPerSend
+	}
+	if queueMaxShards > 0 {
+		conf.Monitoring.QueueConfig.MaxShards = &queueMaxShards
+	}
+	if queueMinBackoff != "" {
+		conf.Monitoring.QueueConfig.MinBackoff = &queueMinBackoff
+	}
+	if queueMinShards > 0 {
+		conf.Monitoring.QueueConfig.MinShards = &queueMinShards
+	}
+	conf.Monitoring.QueueConfig.RetryOnHttp429 = &queueRetryOnHttp429
+	if queueSampleAgeLimit != "" {
+		conf.Monitoring.QueueConfig.SampleAgeLimit = &queueSampleAgeLimit
+	}
 
 	// parse grafana URL
 	conf.GrafanaURL, err = url.Parse(grafanaURL)

--- a/docs/monitoring/README.md
+++ b/docs/monitoring/README.md
@@ -1,5 +1,10 @@
 # Introduction
 
-The Observability Operator is in charge of configuring the Prometheus Agent instances running in workload clusters like remote write configuration, [sharding](sharding.md) and so on.
+The Observability Operator is in charge of configuring the Prometheus Agent instances running in workload clusters like remote write configuration, [sharding](sharding.md), [queue configuration](queue-config.md) and so on.
+
+## Configuration Topics
+
+- [Sharding](sharding.md) - Configure automatic scaling of monitoring agents based on time series count
+- [Queue Configuration](queue-config.md) - Configure Alloy remote write queue parameters for optimal performance
 
 TODO(atlas): Add operator specific documentation here ("sequence diagrams", list of created and managed resources)

--- a/docs/monitoring/queue-config.md
+++ b/docs/monitoring/queue-config.md
@@ -1,0 +1,109 @@
+# Alloy Queue Configuration
+
+The observability operator supports configuring all Alloy remote write queue parameters through helm values. This allows you to tune the queue behavior based on your specific requirements.
+
+## Configuration
+
+### Helm Values
+
+All queue configuration fields are optional. When not specified, Alloy uses its default values. Configure them in your helm values:
+
+```yaml
+monitoring:
+  queueConfig:
+    # Maximum time samples wait in the buffer before sending (default: "5s")
+    batchSendDeadline: "10s"
+    
+    # Number of samples to buffer per shard (default: 10000)
+    capacity: 15000
+    
+    # Maximum retry delay (default: "5s")
+    maxBackoff: "10s"
+    
+    # Maximum number of samples per send (default: 2000)
+    maxSamplesPerSend: 5000
+    
+    # Maximum number of concurrent shards (default: 50)
+    maxShards: 100
+    
+    # Initial retry delay (default: "30ms")
+    minBackoff: "50ms"
+    
+    # Minimum number of concurrent shards (default: 1)
+    minShards: 2
+    
+    # Retry when an HTTP 429 status code is received (default: true)
+    retryOnHttp429: false
+    
+    # Maximum age of samples to send (default: "0s" - disabled)
+    sampleAgeLimit: "1h"
+```
+
+### Command Line Flags
+
+The queue configuration can also be set via command line flags:
+
+- `--monitoring-queue-config-batch-send-deadline`
+- `--monitoring-queue-config-capacity`
+- `--monitoring-queue-config-max-backoff`
+- `--monitoring-queue-config-max-samples-per-send`
+- `--monitoring-queue-config-max-shards`
+- `--monitoring-queue-config-min-backoff`
+- `--monitoring-queue-config-min-shards`
+- `--monitoring-queue-config-retry-on-http-429`
+- `--monitoring-queue-config-sample-age-limit`
+
+## Queue Configuration Parameters
+
+### `batchSendDeadline`
+Maximum time samples wait in the buffer before sending. Smaller values reduce latency but may increase network overhead.
+
+### `capacity`
+Number of samples to buffer per shard. Higher values allow for better batching but use more memory.
+
+### `maxBackoff` / `minBackoff`
+Control the retry delay range. The backoff time starts at `minBackoff` and doubles for each retry up to `maxBackoff`.
+
+### `maxSamplesPerSend`
+Maximum number of samples per send request. Higher values improve throughput but may hit server-side limits.
+
+### `maxShards` / `minShards`
+Control the number of concurrent shards. More shards increase parallelism but also resource usage. Alloy automatically scales shards between these limits based on queue pressure.
+
+### `retryOnHttp429`
+Whether to retry when receiving HTTP 429 (Too Many Requests) responses. When enabled, Alloy respects `Retry-After` headers.
+
+### `sampleAgeLimit`
+Maximum age of samples to send. Older samples are dropped. Use "0s" to disable (send all samples regardless of age).
+
+## Tuning Guidelines
+
+### High Throughput Environments
+- Increase `maxShards` and `maxSamplesPerSend`
+- Consider increasing `capacity` for better batching
+- Monitor queue depth and adjust accordingly
+
+### Low Latency Requirements
+- Decrease `batchSendDeadline`
+- Consider increasing `minShards` for more parallelism
+
+### Memory Constrained Environments
+- Decrease `capacity` and `maxShards`
+- Monitor memory usage and queue performance
+
+### Unreliable Networks
+- Increase `maxBackoff` and enable `retryOnHttp429`
+- Consider shorter `sampleAgeLimit` to avoid accumulating stale data
+
+## Monitoring
+
+Monitor these metrics to understand queue behavior:
+
+- `prometheus_remote_storage_shards`: Current number of shards
+- `prometheus_remote_storage_shards_desired`: Desired number of shards
+- `prometheus_remote_storage_samples_pending`: Samples pending in queues
+- `prometheus_remote_storage_shard_capacity`: Capacity of shards
+
+## References
+
+- [Grafana Alloy prometheus.remote_write Documentation](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/#queue_config)

--- a/docs/monitoring/queue-config.md
+++ b/docs/monitoring/queue-config.md
@@ -55,26 +55,7 @@ The queue configuration can also be set via command line flags:
 
 ## Queue Configuration Parameters
 
-### `batchSendDeadline`
-Maximum time samples wait in the buffer before sending. Smaller values reduce latency but may increase network overhead.
-
-### `capacity`
-Number of samples to buffer per shard. Higher values allow for better batching but use more memory.
-
-### `maxBackoff` / `minBackoff`
-Control the retry delay range. The backoff time starts at `minBackoff` and doubles for each retry up to `maxBackoff`.
-
-### `maxSamplesPerSend`
-Maximum number of samples per send request. Higher values improve throughput but may hit server-side limits.
-
-### `maxShards` / `minShards`
-Control the number of concurrent shards. More shards increase parallelism but also resource usage. Alloy automatically scales shards between these limits based on queue pressure.
-
-### `retryOnHttp429`
-Whether to retry when receiving HTTP 429 (Too Many Requests) responses. When enabled, Alloy respects `Retry-After` headers.
-
-### `sampleAgeLimit`
-Maximum age of samples to send. Older samples are dropped. Use "0s" to disable (send all samples regardless of age).
+For detailed information about each queue configuration parameter, see the [Grafana Alloy prometheus.remote_write queue_config documentation](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/#queue_config).
 
 ## Tuning Guidelines
 
@@ -97,7 +78,7 @@ Maximum age of samples to send. Older samples are dropped. Use "0s" to disable (
 
 ## Monitoring
 
-Monitor these metrics to understand queue behavior:
+Monitor these metrics to understand queue behavior. These are visible on the Grafana dashboard `Prometheus / Remote Write` with ID `promRW001/prometheus-remote-write`:
 
 - `prometheus_remote_storage_shards`: Current number of shards
 - `prometheus_remote_storage_shards_desired`: Desired number of shards

--- a/helm/observability-operator/templates/deployment.yaml
+++ b/helm/observability-operator/templates/deployment.yaml
@@ -39,6 +39,33 @@ spec:
         - --monitoring-sharding-scale-up-series-count={{ $.Values.monitoring.sharding.scaleUpSeriesCount }}
         - --monitoring-sharding-scale-down-percentage={{ $.Values.monitoring.sharding.scaleDownPercentage }}
         - --monitoring-wal-truncate-frequency={{ $.Values.monitoring.wal.truncateFrequency }}
+        {{- if .Values.monitoring.queueConfig.batchSendDeadline }}
+        - --monitoring-queue-config-batch-send-deadline={{ $.Values.monitoring.queueConfig.batchSendDeadline }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.capacity }}
+        - --monitoring-queue-config-capacity={{ $.Values.monitoring.queueConfig.capacity }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.maxBackoff }}
+        - --monitoring-queue-config-max-backoff={{ $.Values.monitoring.queueConfig.maxBackoff }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.maxSamplesPerSend }}
+        - --monitoring-queue-config-max-samples-per-send={{ $.Values.monitoring.queueConfig.maxSamplesPerSend }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.maxShards }}
+        - --monitoring-queue-config-max-shards={{ $.Values.monitoring.queueConfig.maxShards }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.minBackoff }}
+        - --monitoring-queue-config-min-backoff={{ $.Values.monitoring.queueConfig.minBackoff }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.minShards }}
+        - --monitoring-queue-config-min-shards={{ $.Values.monitoring.queueConfig.minShards }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.retryOnHttp429 }}
+        - --monitoring-queue-config-retry-on-http-429={{ $.Values.monitoring.queueConfig.retryOnHttp429 }}
+        {{- end }}
+        {{- if .Values.monitoring.queueConfig.sampleAgeLimit }}
+        - --monitoring-queue-config-sample-age-limit={{ $.Values.monitoring.queueConfig.sampleAgeLimit }}
+        {{- end }}
         - --operator-namespace={{ include "resource.default.namespace" . }}
         {{- if .Values.monitoring.prometheusVersion }}
         - --prometheus-version={{ $.Values.monitoring.prometheusVersion }}

--- a/helm/observability-operator/values.schema.json
+++ b/helm/observability-operator/values.schema.json
@@ -92,6 +92,52 @@
                             "type": "string"
                         }
                     }
+                },
+                "queueConfig": {
+                    "type": "object",
+                    "description": "Queue configuration for remote write",
+                    "properties": {
+                        "batchSendDeadline": {
+                            "type": "string",
+                            "description": "Maximum time samples wait in the buffer before sending (e.g., '5s')"
+                        },
+                        "capacity": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Number of samples to buffer per shard"
+                        },
+                        "maxBackoff": {
+                            "type": "string",
+                            "description": "Maximum retry delay (e.g., '5s')"
+                        },
+                        "maxSamplesPerSend": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Maximum number of samples per send"
+                        },
+                        "maxShards": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Maximum number of concurrent shards"
+                        },
+                        "minBackoff": {
+                            "type": "string",
+                            "description": "Initial retry delay (e.g., '30ms')"
+                        },
+                        "minShards": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "description": "Minimum number of concurrent shards"
+                        },
+                        "retryOnHttp429": {
+                            "type": "boolean",
+                            "description": "Retry when an HTTP 429 status code is received"
+                        },
+                        "sampleAgeLimit": {
+                            "type": "string",
+                            "description": "Maximum age of samples to send (e.g., '30m')"
+                        }
+                    }
                 }
             }
         },

--- a/helm/observability-operator/values.yaml
+++ b/helm/observability-operator/values.yaml
@@ -30,6 +30,17 @@ monitoring:
   wal:
     # -- Configures the WAL truncation frequency
     truncateFrequency: 15m
+  queueConfig:
+    # -- Queue configuration for remote write. If not set, Alloy defaults will be used
+    # batchSendDeadline: "5s"
+    capacity: 30000
+    # maxBackoff: "5s"
+    maxSamplesPerSend: 150000
+    maxShards: 10
+    # minBackoff: "30ms"
+    # minShards: 1
+    # retryOnHttp429: true
+    sampleAgeLimit: "30m"
 
 operator:
   # -- Configures the resources for the operator deployment

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -154,10 +154,15 @@ func (a *Service) generateAlloyConfig(ctx context.Context, cluster *clusterv1.Cl
 		Tenants         []string
 		DefaultTenantID string
 
-		QueueConfigCapacity          int
-		QueueConfigMaxSamplesPerSend int
-		QueueConfigMaxShards         int
-		QueueConfigSampleAgeLimit    string
+		QueueConfigBatchSendDeadline *string
+		QueueConfigCapacity          *int
+		QueueConfigMaxBackoff        *string
+		QueueConfigMaxSamplesPerSend *int
+		QueueConfigMaxShards         *int
+		QueueConfigMinBackoff        *string
+		QueueConfigMinShards         *int
+		QueueConfigRetryOnHttp429    *bool
+		QueueConfigSampleAgeLimit    *string
 
 		WALTruncateFrequency string
 
@@ -181,10 +186,15 @@ func (a *Service) generateAlloyConfig(ctx context.Context, cluster *clusterv1.Cl
 		Tenants:         tenants,
 		DefaultTenantID: commonmonitoring.DefaultWriteTenant,
 
-		QueueConfigCapacity:          commonmonitoring.QueueConfigCapacity,
-		QueueConfigMaxSamplesPerSend: commonmonitoring.QueueConfigMaxSamplesPerSend,
-		QueueConfigMaxShards:         commonmonitoring.QueueConfigMaxShards,
-		QueueConfigSampleAgeLimit:    commonmonitoring.QueueConfigSampleAgeLimit,
+		QueueConfigBatchSendDeadline: a.MonitoringConfig.QueueConfig.BatchSendDeadline,
+		QueueConfigCapacity:          a.MonitoringConfig.QueueConfig.Capacity,
+		QueueConfigMaxBackoff:        a.MonitoringConfig.QueueConfig.MaxBackoff,
+		QueueConfigMaxSamplesPerSend: a.MonitoringConfig.QueueConfig.MaxSamplesPerSend,
+		QueueConfigMaxShards:         a.MonitoringConfig.QueueConfig.MaxShards,
+		QueueConfigMinBackoff:        a.MonitoringConfig.QueueConfig.MinBackoff,
+		QueueConfigMinShards:         a.MonitoringConfig.QueueConfig.MinShards,
+		QueueConfigRetryOnHttp429:    a.MonitoringConfig.QueueConfig.RetryOnHttp429,
+		QueueConfigSampleAgeLimit:    a.MonitoringConfig.QueueConfig.SampleAgeLimit,
 
 		WALTruncateFrequency: a.MonitoringConfig.WALTruncateFrequency.String(),
 

--- a/pkg/monitoring/alloy/configmap_test.go
+++ b/pkg/monitoring/alloy/configmap_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/blang/semver/v4"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 
 	"github.com/giantswarm/observability-operator/pkg/common"
@@ -195,6 +196,12 @@ func TestGenerateAlloyConfig(t *testing.T) {
 				},
 				MonitoringConfig: monitoring.Config{
 					WALTruncateFrequency: time.Minute,
+					QueueConfig: monitoring.QueueConfig{
+						Capacity:          ptr.To(30000),
+						MaxShards:         ptr.To(10),
+						MaxSamplesPerSend: ptr.To(150000),
+						SampleAgeLimit:    ptr.To("30m"),
+					},
 				},
 			}
 

--- a/pkg/monitoring/alloy/templates/alloy-config.alloy.template
+++ b/pkg/monitoring/alloy/templates/alloy-config.alloy.template
@@ -140,12 +140,37 @@ prometheus.remote_write "{{ . }}" {
     tls_config {
       insecure_skip_verify = {{ $.MimirRemoteWriteTLSInsecureSkipVerify }}
     }
+    {{- if or $.QueueConfigBatchSendDeadline $.QueueConfigCapacity $.QueueConfigMaxBackoff $.QueueConfigMaxSamplesPerSend $.QueueConfigMaxShards $.QueueConfigMinBackoff $.QueueConfigMinShards $.QueueConfigRetryOnHttp429 $.QueueConfigSampleAgeLimit }}
     queue_config {
+      {{- if $.QueueConfigBatchSendDeadline }}
+      batch_send_deadline = "{{ $.QueueConfigBatchSendDeadline }}"
+      {{- end }}
+      {{- if $.QueueConfigCapacity }}
       capacity             = {{ $.QueueConfigCapacity }}
-      max_shards           = {{ $.QueueConfigMaxShards }}
+      {{- end }}
+      {{- if $.QueueConfigMaxBackoff }}
+      max_backoff          = "{{ $.QueueConfigMaxBackoff }}"
+      {{- end }}
+      {{- if $.QueueConfigMaxSamplesPerSend }}
       max_samples_per_send = {{ $.QueueConfigMaxSamplesPerSend }}
+      {{- end }}
+      {{- if $.QueueConfigMaxShards }}
+      max_shards           = {{ $.QueueConfigMaxShards }}
+      {{- end }}
+      {{- if $.QueueConfigMinBackoff }}
+      min_backoff          = "{{ $.QueueConfigMinBackoff }}"
+      {{- end }}
+      {{- if $.QueueConfigMinShards }}
+      min_shards           = {{ $.QueueConfigMinShards }}
+      {{- end }}
+      {{- if $.QueueConfigRetryOnHttp429 }}
+      retry_on_http_429    = {{ $.QueueConfigRetryOnHttp429 }}
+      {{- end }}
+      {{- if $.QueueConfigSampleAgeLimit }}
       sample_age_limit     = "{{ $.QueueConfigSampleAgeLimit }}"
+      {{- end }}
     }
+    {{- end }}
   }
   wal {
     truncate_frequency = "{{ $.WALTruncateFrequency }}"

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.mc.river
@@ -120,8 +120,8 @@ prometheus.remote_write "giantswarm" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_defaulttenant.wc.river
@@ -131,8 +131,8 @@ prometheus.remote_write "giantswarm" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.170.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.170.mc.river
@@ -64,8 +64,8 @@ prometheus.remote_write "tenant1" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }
@@ -141,8 +141,8 @@ prometheus.remote_write "tenant2" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.190.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.190.mc.river
@@ -96,8 +96,8 @@ prometheus.remote_write "tenant1" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }
@@ -173,8 +173,8 @@ prometheus.remote_write "tenant2" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.mc.river
@@ -96,8 +96,8 @@ prometheus.remote_write "tenant1" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }
@@ -173,8 +173,8 @@ prometheus.remote_write "tenant2" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_multitenants.wc.river
@@ -118,8 +118,8 @@ prometheus.remote_write "tenant1" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }
@@ -195,8 +195,8 @@ prometheus.remote_write "tenant2" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.mc.river
@@ -80,8 +80,8 @@ prometheus.remote_write "tenant1" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
+++ b/pkg/monitoring/alloy/testdata/alloy_config_singletenant.wc.river
@@ -91,8 +91,8 @@ prometheus.remote_write "tenant1" {
     }
     queue_config {
       capacity             = 30000
-      max_shards           = 10
       max_samples_per_send = 150000
+      max_shards           = 10
       sample_age_limit     = "30m"
     }
   }

--- a/pkg/monitoring/config.go
+++ b/pkg/monitoring/config.go
@@ -11,6 +11,19 @@ import (
 
 const MonitoringLabel = "giantswarm.io/monitoring"
 
+// QueueConfig represents the configuration for the remote write queue.
+type QueueConfig struct {
+	BatchSendDeadline *string
+	Capacity          *int
+	MaxBackoff        *string
+	MaxSamplesPerSend *int
+	MaxShards         *int
+	MinBackoff        *string
+	MinShards         *int
+	RetryOnHttp429    *bool
+	SampleAgeLimit    *string
+}
+
 // Config represents the configuration used by the monitoring package.
 type Config struct {
 	Enabled bool
@@ -25,6 +38,7 @@ type Config struct {
 	WALTruncateFrequency time.Duration
 	PrometheusVersion    string
 	MetricsQueryURL      string
+	QueueConfig          QueueConfig
 }
 
 // Monitoring should be enabled when all conditions are met:


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://docs.google.com/document/d/1BmVl-M8bsgEYbso0BioaX5UnXb_-yX0wpL62H3tA5VI/edit?tab=t.0

This pull request adds support for configuring all Alloy remote write queue parameters through both Helm values and command line flags. This allows users to fine-tune the remote write queue behavior for monitoring workloads, improving flexibility and performance tuning. The changes include updates to documentation, configuration schemas, code logic, and tests to support these new options.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [x] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
