### PR TITLE
add initial logging-config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Add support for PrometheusOperator `ScrapeConfig` CRDs. This requires --stability.level=experimental
+- Add logging-enabled flag towards the logging-operator -> observability-operator merger.
 
 ## [0.42.0] - 2025-09-17
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -147,6 +147,10 @@ func parseFlags() (err error) {
 	flag.BoolVar(&cfg.Tracing.Enabled, "tracing-enabled", false,
 		"Enable distributed tracing support in Grafana.")
 
+	// Logging configuration flags
+	flag.BoolVar(&cfg.Logging.Enabled, "logging-enabled", false,
+		"Enable logging support in Grafana.")
+
 	// Zap logging options
 	opts := zap.Options{
 		Development: false,

--- a/helm/observability-operator/templates/deployment.yaml
+++ b/helm/observability-operator/templates/deployment.yaml
@@ -71,6 +71,7 @@ spec:
         - --prometheus-version={{ $.Values.monitoring.prometheusVersion }}
         {{- end }}
         - --tracing-enabled={{ $.Values.tracing.enabled }}
+        - --logging-enabled={{ $.Values.logging.enabled }}
         - --webhook-cert-path=/tmp/k8s-webhook-server/serving-certs
         env:
         - name: ENABLE_WEBHOOKS

--- a/helm/observability-operator/values.schema.json
+++ b/helm/observability-operator/values.schema.json
@@ -222,6 +222,24 @@
                 }
             }
         },
+        "tracing": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable distributed tracing support"
+                }
+            }
+        },
+        "logging": {
+            "type": "object",
+            "properties": {
+                "enabled": {
+                    "type": "boolean",
+                    "description": "Enable or disable logging support"
+                }
+            }
+        },
         "webhook": {
             "type": "object",
             "properties": {

--- a/helm/observability-operator/values.yaml
+++ b/helm/observability-operator/values.yaml
@@ -46,6 +46,10 @@ tracing:
   # -- Enable or disable distributed tracing support
   enabled: false
 
+logging:
+  # -- Enable or disable logging support
+  enabled: false
+
 operator:
   # -- Configures the resources for the operator deployment
   resources:

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -71,7 +71,7 @@ func (c ClusterConfig) GetClusterType(cluster *clusterv1.Cluster) string {
 }
 
 // GetClusterProvider returns the provider for the given cluster.
-func GetClusterProvider(cluster *clusterv1.Cluster) (string, error) {
+func (c ClusterConfig) GetClusterProvider(cluster *clusterv1.Cluster) (string, error) {
 	switch cluster.Spec.InfrastructureRef.Kind {
 	case AWSClusterKind:
 		return AWSClusterKindProvider, nil

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -10,9 +10,10 @@ type Config struct {
 	Operator OperatorConfig
 
 	// Subsystem configurations
+	Logging    LoggingConfig
+	Grafana    GrafanaConfig
 	Monitoring MonitoringConfig
 	Tracing    TracingConfig
-	Grafana    GrafanaConfig
 
 	// Management cluster configuration
 	Cluster ClusterConfig
@@ -31,14 +32,17 @@ func (c Config) Validate() error {
 	if err := c.Operator.Validate(); err != nil {
 		return fmt.Errorf("operator config validation failed: %w", err)
 	}
-	if err := c.Monitoring.Validate(); err != nil {
-		return fmt.Errorf("monitoring config validation failed: %w", err)
+	if err := c.Logging.Validate(); err != nil {
+		return fmt.Errorf("logging config validation failed: %w", err)
+	}
+	if err := c.Grafana.Validate(); err != nil {
+		return fmt.Errorf("grafana config validation failed: %w", err)
 	}
 	if err := c.Tracing.Validate(); err != nil {
 		return fmt.Errorf("tracing config validation failed: %w", err)
 	}
-	if err := c.Grafana.Validate(); err != nil {
-		return fmt.Errorf("grafana config validation failed: %w", err)
+	if err := c.Monitoring.Validate(); err != nil {
+		return fmt.Errorf("monitoring config validation failed: %w", err)
 	}
 	if err := c.Cluster.Validate(); err != nil {
 		return fmt.Errorf("cluster config validation failed: %w", err)

--- a/pkg/config/logging.go
+++ b/pkg/config/logging.go
@@ -1,0 +1,12 @@
+package config
+
+// LoggingConfig represents the configuration used by the logging package.
+type LoggingConfig struct {
+	Enabled bool
+}
+
+// Validate validates the logging configuration
+func (c LoggingConfig) Validate() error {
+	// Logging config is always valid since it's just a boolean flag
+	return nil
+}

--- a/pkg/monitoring/alloy/configmap.go
+++ b/pkg/monitoring/alloy/configmap.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/giantswarm/observability-operator/pkg/common/labels"
 	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
-	"github.com/giantswarm/observability-operator/pkg/config"
 	"github.com/giantswarm/observability-operator/pkg/metrics"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir/querier"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/sharding"
@@ -131,7 +130,7 @@ func (a *Service) generateAlloyConfig(ctx context.Context, cluster *clusterv1.Cl
 		return "", fmt.Errorf("failed to read organization: %w", err)
 	}
 
-	provider, err := config.GetClusterProvider(cluster)
+	provider, err := a.Config.Cluster.GetClusterProvider(cluster)
 	if err != nil {
 		return "", fmt.Errorf("failed to get cluster provider: %w", err)
 	}

--- a/pkg/monitoring/prometheusagent/configmap.go
+++ b/pkg/monitoring/prometheusagent/configmap.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/yaml"
 
 	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
-	"github.com/giantswarm/observability-operator/pkg/config"
 	"github.com/giantswarm/observability-operator/pkg/metrics"
 	"github.com/giantswarm/observability-operator/pkg/monitoring/mimir/querier"
 )
@@ -24,7 +23,7 @@ func (pas PrometheusAgentService) buildRemoteWriteConfig(ctx context.Context,
 		return nil, fmt.Errorf("failed to get cluster organization: %w", err)
 	}
 
-	provider, err := config.GetClusterProvider(cluster)
+	provider, err := pas.Config.Cluster.GetClusterProvider(cluster)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get cluster provider: %w", err)
 	}


### PR DESCRIPTION
### What this PR does / why we need it

Add logging-config flag to the observability operator to help with the merge of the logging-operator and the observability operator

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
