### PR TITLE
Refactor the webhook suite test architecture to be able to accomodate the future v1alpha2 grafana organization CR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor webhook test suite architecture to use shared testutil package and individual test suites per API version
+
 ## [0.43.1] - 2025-10-07
 
 ### Fixed

--- a/Makefile.kubebuilder.mk
+++ b/Makefile.kubebuilder.mk
@@ -17,16 +17,16 @@
 # ==================================================================================
 
 # Core tool versions (aligned with kubebuilder defaults and auto-detection)
-CONTROLLER_TOOLS_VERSION ?= v0.18.0
-KUSTOMIZE_VERSION ?= v5.6.0
+CONTROLLER_TOOLS_VERSION ?= v0.19.0
+KUSTOMIZE_VERSION ?= v5.7.1
 # Auto-detect ENVTEST version from controller-runtime dependency
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime 2>/dev/null | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 # Auto-detect Kubernetes version from k8s.io/api dependency  
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api 2>/dev/null | awk -F'[v.]' '{printf "1.%d", $$3}')
 
 # Code quality and development tool versions
-GOLANGCI_LINT_VERSION ?= v2.1.6
-GINKGO_VERSION ?= v2.23.4
+GOLANGCI_LINT_VERSION ?= v2.4.0
+GINKGO_VERSION ?= v2.26.0
 
 # Directories
 API_DIR := $(shell [ -d api ] && echo api || echo pkg/apis)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,6 +32,7 @@ import (
 	observabilityv1alpha1 "github.com/giantswarm/observability-operator/api/v1alpha1"
 	"github.com/giantswarm/observability-operator/internal/controller"
 	webhookcorev1 "github.com/giantswarm/observability-operator/internal/webhook/v1"
+	webhookcorev1alpha1 "github.com/giantswarm/observability-operator/internal/webhook/v1alpha1"
 	commonmonitoring "github.com/giantswarm/observability-operator/pkg/common/monitoring"
 	"github.com/giantswarm/observability-operator/pkg/config"
 	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
@@ -325,11 +326,11 @@ func setupApplication() error {
 		if err = webhookcorev1.SetupAlertmanagerConfigSecretWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create webhook (Secret): %w", err)
 		}
-		if err = webhookcorev1.SetupGrafanaOrganizationWebhookWithManager(mgr); err != nil {
-			return fmt.Errorf("unable to create webhook (GrafanaOrganization): %w", err)
-		}
 		if err = webhookcorev1.SetupDashboardConfigMapWebhookWithManager(mgr); err != nil {
 			return fmt.Errorf("unable to create webhook (DashboardConfigMap): %w", err)
+		}
+		if err = webhookcorev1alpha1.SetupGrafanaOrganizationWebhookWithManager(mgr); err != nil {
+			return fmt.Errorf("unable to create webhook (GrafanaOrganization): %w", err)
 		}
 	}
 	//+kubebuilder:scaffold:builder

--- a/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
+++ b/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
@@ -5,7 +5,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.18.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: grafanaorganizations.observability.giantswarm.io
 spec:
   group: observability.giantswarm.io

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -30,26 +30,6 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
-      path: /validate-v1alpha1-grafana-organization
-  failurePolicy: Fail
-  name: vgrafanaorganization.kb.io
-  rules:
-  - apiGroups:
-    - observability.giantswarm.io
-    apiVersions:
-    - v1alpha1
-    operations:
-    - CREATE
-    - UPDATE
-    resources:
-    - grafanaorganizations
-  sideEffects: None
-- admissionReviewVersions:
-  - v1
-  clientConfig:
-    service:
-      name: webhook-service
-      namespace: system
       path: /validate-alertmanager-config
   failurePolicy: Fail
   name: vsecret-v1.kb.io
@@ -63,4 +43,24 @@ webhooks:
     - UPDATE
     resources:
     - secrets
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-v1alpha1-grafana-organization
+  failurePolicy: Fail
+  name: vgrafanaorganization.kb.io
+  rules:
+  - apiGroups:
+    - observability.giantswarm.io
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - grafanaorganizations
   sideEffects: None

--- a/internal/webhook/testutil/suite.go
+++ b/internal/webhook/testutil/suite.go
@@ -1,0 +1,249 @@
+/*
+Copyright 2025.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"context"
+	"crypto/tls"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+// WebhookTestSuite provides common functionality for webhook test suites
+type WebhookTestSuite struct {
+	Ctx       context.Context
+	Cancel    context.CancelFunc
+	K8sClient client.Client
+	Cfg       *rest.Config
+	TestEnv   *envtest.Environment
+}
+
+// WebhookSetupFunc is a function type for setting up webhooks with a manager
+type WebhookSetupFunc func(mgr ctrl.Manager) error
+
+// SchemeSetupFunc is a function type for adding types to a scheme
+type SchemeSetupFunc func(s *runtime.Scheme) error
+
+// WebhookSuiteConfig holds configuration for setting up a webhook test suite
+type WebhookSuiteConfig struct {
+	SuiteName         string
+	SchemeSetupFuncs  []SchemeSetupFunc
+	WebhookSetupFuncs []WebhookSetupFunc
+}
+
+// NewWebhookTestSuite creates a new webhook test suite with common functionality
+func NewWebhookTestSuite() *WebhookTestSuite {
+	return &WebhookTestSuite{}
+}
+
+// SetupSuite sets up the test environment for webhook testing
+func (s *WebhookTestSuite) SetupSuite(config WebhookSuiteConfig) {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	// Check if we have KUBEBUILDER_ASSETS or can find them automatically
+	kubeBuilderAssets := getKubeBuilderAssets()
+	if kubeBuilderAssets == "" {
+		Skip("KUBEBUILDER_ASSETS not set and envtest binaries not found. Run 'make setup-envtest' to set up test environment.")
+	}
+
+	s.Ctx, s.Cancel = context.WithCancel(context.Background())
+
+	// Setup schemes
+	var err error
+	for _, setupFunc := range config.SchemeSetupFuncs {
+		err = setupFunc(scheme.Scheme)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	By("bootstrapping test environment")
+	s.TestEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: false,
+		BinaryAssetsDirectory: kubeBuilderAssets,
+
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			Paths: []string{filepath.Join("..", "..", "..", "config", "webhook")},
+		},
+	}
+
+	s.Cfg, err = s.TestEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(s.Cfg).NotTo(BeNil())
+
+	s.K8sClient, err = client.New(s.Cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(s.K8sClient).NotTo(BeNil())
+
+	// Start webhook server using Manager
+	webhookInstallOptions := &s.TestEnv.WebhookInstallOptions
+	mgr, err := ctrl.NewManager(s.Cfg, ctrl.Options{
+		Scheme: scheme.Scheme,
+		WebhookServer: webhook.NewServer(webhook.Options{
+			Host:    webhookInstallOptions.LocalServingHost,
+			Port:    webhookInstallOptions.LocalServingPort,
+			CertDir: webhookInstallOptions.LocalServingCertDir,
+		}),
+		LeaderElection: false,
+		Metrics:        metricsserver.Options{BindAddress: "0"},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	// Setup webhooks
+	for _, setupFunc := range config.WebhookSetupFuncs {
+		err = setupFunc(mgr)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	go func() {
+		defer GinkgoRecover()
+		err = mgr.Start(s.Ctx)
+		Expect(err).NotTo(HaveOccurred())
+	}()
+
+	// Wait for the webhook server to get ready
+	dialer := &net.Dialer{Timeout: time.Second}
+	addrPort := fmt.Sprintf("%s:%d", webhookInstallOptions.LocalServingHost, webhookInstallOptions.LocalServingPort)
+	Eventually(func() error {
+		conn, err := tls.DialWithDialer(dialer, "tcp", addrPort, &tls.Config{InsecureSkipVerify: true}) // nolint:gosec
+		if err != nil {
+			return err
+		}
+		return conn.Close()
+	}).Should(Succeed())
+}
+
+// TeardownSuite tears down the test environment
+func (s *WebhookTestSuite) TeardownSuite() {
+	By("tearing down the test environment")
+
+	// Only check for assets if we need to clean up
+	kubeBuilderAssets := getKubeBuilderAssets()
+	if kubeBuilderAssets == "" {
+		// If no assets were available, the test was skipped, so nothing to clean up
+		return
+	}
+
+	s.Cancel()
+	err := s.TestEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+}
+
+// getKubeBuilderAssets attempts to get KUBEBUILDER_ASSETS from environment
+// or find the binaries automatically. Returns empty string if neither is available.
+func getKubeBuilderAssets() string {
+	// First try environment variable
+	if value := os.Getenv("KUBEBUILDER_ASSETS"); value != "" {
+		return value
+	}
+
+	// If not set, try to find binaries automatically
+	binDir := getFirstFoundEnvTestBinaryDir()
+	if binDir != "" {
+		logf.Log.Info("Using automatically detected envtest binaries", "path", binDir)
+		return binDir
+	}
+
+	return ""
+}
+
+// getFirstFoundEnvTestBinaryDir locates the first binary in the specified path.
+// ENVTEST-based tests depend on specific binaries, usually located in paths set by
+// controller-runtime. When running tests directly (e.g., via an IDE) without using
+// Makefile targets, the 'BinaryAssetsDirectory' must be explicitly configured.
+//
+// This function streamlines the process by finding the required binaries, similar to
+// setting the 'KUBEBUILDER_ASSETS' environment variable. To ensure the binaries are
+// properly set up, run 'make setup-envtest' beforehand.
+func getFirstFoundEnvTestBinaryDir() string {
+	// Try common paths where envtest binaries might be located
+	possiblePaths := []string{
+		filepath.Join("..", "..", "..", "bin", "k8s"),        // bin/k8s/
+		filepath.Join("..", "..", "..", "bin", "k8s", "k8s"), // bin/k8s/k8s/ (setup-envtest creates this nested structure)
+	}
+
+	for _, basePath := range possiblePaths {
+		entries, err := os.ReadDir(basePath)
+		if err != nil {
+			logf.Log.V(1).Info("Failed to read directory", "path", basePath, "error", err)
+			continue
+		}
+		for _, entry := range entries {
+			if entry.IsDir() {
+				binPath := filepath.Join(basePath, entry.Name())
+				// Verify this directory contains the expected binaries
+				if hasEnvTestBinaries(binPath) {
+					return binPath
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// hasEnvTestBinaries checks if a directory contains the expected envtest binaries
+func hasEnvTestBinaries(path string) bool {
+	expectedBinaries := []string{"kube-apiserver", "etcd", "kubectl"}
+	for _, binary := range expectedBinaries {
+		if _, err := os.Stat(filepath.Join(path, binary)); os.IsNotExist(err) {
+			return false
+		}
+	}
+	return true
+}
+
+// SetupWebhookTestSuite is a simplified helper function that sets up a webhook test suite
+// with common default configurations
+func SetupWebhookTestSuite(webhookSetupFuncs ...WebhookSetupFunc) *WebhookTestSuite {
+	suite := NewWebhookTestSuite()
+	
+	config := WebhookSuiteConfig{
+		SuiteName: "Webhook Test Suite",
+		SchemeSetupFuncs: []SchemeSetupFunc{
+			// Add core scheme
+			func(s *runtime.Scheme) error {
+				return nil // corev1 is already added by default
+			},
+			// Add observability scheme
+			func(s *runtime.Scheme) error {
+				// Import the API package and add its scheme
+				// This will be done in the specific webhook suite files
+				return nil
+			},
+		},
+		WebhookSetupFuncs: webhookSetupFuncs,
+	}
+	
+	suite.SetupSuite(config)
+	return suite
+}

--- a/internal/webhook/v1alpha1/grafanaorganization_webhook.go
+++ b/internal/webhook/v1alpha1/grafanaorganization_webhook.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package v1alpha1
 
 import (
 	"context"

--- a/internal/webhook/v1alpha1/grafanaorganization_webhook_test.go
+++ b/internal/webhook/v1alpha1/grafanaorganization_webhook_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package v1alpha1
 
 import (
 	"context"
@@ -28,6 +28,7 @@ import (
 	observabilityv1alpha1 "github.com/giantswarm/observability-operator/api/v1alpha1"
 )
 
+// GrafanaOrganizationWebhookSpecs returns the Describe blocks for testing the GrafanaOrganization webhook
 var _ = Describe("GrafanaOrganization Validation", func() {
 	var ctx context.Context
 

--- a/internal/webhook/v1alpha1/webhook_suite_test.go
+++ b/internal/webhook/v1alpha1/webhook_suite_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1
+package v1alpha1
 
 import (
 	"testing"
@@ -27,7 +27,6 @@ import (
 
 	observabilityv1alpha1 "github.com/giantswarm/observability-operator/api/v1alpha1"
 	"github.com/giantswarm/observability-operator/internal/webhook/testutil"
-	webhookv1alpha1 "github.com/giantswarm/observability-operator/internal/webhook/v1alpha1"
 )
 
 // k8sClient is the package-level client that will be set by the test suite
@@ -36,7 +35,7 @@ var testSuite *testutil.WebhookTestSuite
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "V1 Webhook Suite")
+	RunSpecs(t, "V1Alpha1 Webhook Suite")
 }
 
 var _ = BeforeSuite(func() {
@@ -45,7 +44,7 @@ var _ = BeforeSuite(func() {
 	
 	// Set up the webhook test environment with all needed schemes and webhooks
 	config := testutil.WebhookSuiteConfig{
-		SuiteName: "V1 Webhook Suite",
+		SuiteName: "V1Alpha1 Webhook Suite",
 		SchemeSetupFuncs: []testutil.SchemeSetupFunc{
 			// Add core v1 scheme (for Secrets, ConfigMaps)
 			corev1.AddToScheme,
@@ -53,11 +52,8 @@ var _ = BeforeSuite(func() {
 			observabilityv1alpha1.AddToScheme,
 		},
 		WebhookSetupFuncs: []testutil.WebhookSetupFunc{
-			// Register v1 webhooks
-			SetupAlertmanagerConfigSecretWebhookWithManager,
-			SetupDashboardConfigMapWebhookWithManager,
-			// Register v1alpha1 webhooks (needed for tenant validation)
-			webhookv1alpha1.SetupGrafanaOrganizationWebhookWithManager,
+			// Register v1alpha1 webhooks
+			SetupGrafanaOrganizationWebhookWithManager,
 		},
 	}
 	

--- a/pkg/tracing/config.go
+++ b/pkg/tracing/config.go
@@ -1,5 +1,0 @@
-package tracing
-
-type Config struct {
-	Enabled bool
-}


### PR DESCRIPTION
### What this PR does / why we need it

This pull request refactors the webhook test suite architecture to improve maintainability and scalability, splits webhook implementations by API version, and updates several dependencies and configuration files accordingly. The most significant changes include extracting shared test utilities, separating webhook logic and tests for different API versions, and updating related manifests and tool versions.

This is needed because the changes that will be introduced to solve https://github.com/giantswarm/giantswarm/issues/33739 will require a new GrafanaOrganization api version

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [ ] Make sure the new features are scoped to supported observability-bundle versions (see `IsSupporting` booleans)
- [ ] Follow deployment test procedure in the tests/manual_e2e directory and have a working branch.
