### PR TITLE
cronitor alert: update ops-recipe URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Breaking (Helm)**: removed the `--alertmanager-enabled` flag (formerly gated by `alerting.enabled`). Use `--controllers-alertmanager-enabled` / `operator.controllers.alertmanager.enabled` instead. Default flipped from `false` to `true` — the Alertmanager controller is now opt-out.
 - internal code refactoring
+- Cronitor alerts: update ops-recipe URL
 
 ### Fixed
 

--- a/pkg/alerting/heartbeat/cronitor.go
+++ b/pkg/alerting/heartbeat/cronitor.go
@@ -119,7 +119,7 @@ func (r *CronitorHeartbeatRepository) makeMonitor() *cronitorMonitor {
 		Schedule:        r.cfg.schedule,
 		Notify:          []string{r.cfg.pipeline},
 		Tags:            tags,
-		Note:            "📗 Runbook: https://intranet.giantswarm.io/docs/support-and-ops/ops-recipes/heartbeat-expired/",
+		Note:            "📗 Runbook: https://intranet.giantswarm.io/docs/support-and-ops/runbooks/install-heartbeat/",
 		RealertInterval: r.cfg.realertInterval,
 	}
 }


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/36425

Update URL for Cronitor alerts, so it links to the new ops-recipe URL.

### Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs under `docs/` and `README.md` updated if the change affects operator behaviour, feature flags, CRD fields, exposed metrics, or configuration
