### PR TITLE
GrafanaOrganization reconciler: improved management of orgID conflicts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Align Grafana client mocks and SSO settings payload handling with the latest `grafana-openapi-client-go` interface so `go build ./...` passes.
+- `GrafanaOrganization` reconciler: improved management of orgID conflicts.
 
 ## [0.67.2] - 2026-04-08
 

--- a/api/v1alpha1/grafanaorganization_conversion.go
+++ b/api/v1alpha1/grafanaorganization_conversion.go
@@ -36,6 +36,7 @@ func (src *GrafanaOrganization) ConvertTo(dstRaw conversion.Hub) error {
 
 	// Convert status
 	dst.Status.OrgID = src.Status.OrgID
+	dst.Status.DisplayName = src.Status.DisplayName
 	dst.Status.DataSources = make([]v1alpha2.DataSource, len(src.Status.DataSources))
 	for i, ds := range src.Status.DataSources {
 		dst.Status.DataSources[i] = v1alpha2.DataSource{
@@ -74,6 +75,7 @@ func (dst *GrafanaOrganization) ConvertFrom(srcRaw conversion.Hub) error {
 
 	// Convert status
 	dst.Status.OrgID = src.Status.OrgID
+	dst.Status.DisplayName = src.Status.DisplayName
 	dst.Status.DataSources = make([]DataSource, len(src.Status.DataSources))
 	for i, ds := range src.Status.DataSources {
 		dst.Status.DataSources[i] = DataSource{

--- a/api/v1alpha1/grafanaorganization_types.go
+++ b/api/v1alpha1/grafanaorganization_types.go
@@ -66,6 +66,11 @@ type GrafanaOrganizationStatus struct {
 	// DataSources is a list of grafana data sources that are available to the Grafana organization.
 	// +optional
 	DataSources []DataSource `json:"dataSources"`
+
+	// DisplayName records the last display name successfully applied to the Grafana
+	// organization referenced by OrgID.
+	// +optional
+	DisplayName string `json:"displayName,omitempty"`
 }
 
 // DataSource defines the name and id for data sources.

--- a/api/v1alpha2/grafanaorganization_types.go
+++ b/api/v1alpha2/grafanaorganization_types.go
@@ -93,6 +93,13 @@ type GrafanaOrganizationStatus struct {
 	// DataSources is a list of grafana data sources that are available to the Grafana organization.
 	// +optional
 	DataSources []DataSource `json:"dataSources"`
+
+	// DisplayName records the last display name successfully applied to the Grafana
+	// organization referenced by OrgID. The reconciler uses it to tell a legitimate
+	// CR rename (status.displayName matches what is currently in Grafana at that ID)
+	// apart from a stale OrgID that now points to an organization owned by another CR.
+	// +optional
+	DisplayName string `json:"displayName,omitempty"`
 }
 
 // DataSource defines the name and id for data sources.

--- a/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
+++ b/config/crd/bases/observability.giantswarm.io_grafanaorganizations.yaml
@@ -137,6 +137,11 @@ spec:
                   - name
                   type: object
                 type: array
+              displayName:
+                description: |-
+                  DisplayName records the last display name successfully applied to the Grafana
+                  organization referenced by OrgID.
+                type: string
               orgID:
                 description: OrgID is the actual organisation ID in grafana.
                 format: int64
@@ -269,6 +274,13 @@ spec:
                   - name
                   type: object
                 type: array
+              displayName:
+                description: |-
+                  DisplayName records the last display name successfully applied to the Grafana
+                  organization referenced by OrgID. The reconciler uses it to tell a legitimate
+                  CR rename (status.displayName matches what is currently in Grafana at that ID)
+                  apart from a stale OrgID that now points to an organization owned by another CR.
+                type: string
               orgID:
                 description: OrgID is the actual organisation ID in grafana.
                 format: int64

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -203,7 +203,7 @@ func (r GrafanaOrganizationReconciler) reconcileCreate(ctx context.Context, graf
 
 	// Update CR status if anything was changed
 	if grafanaOrganization.Status.OrgID != updatedID || grafanaOrganization.Status.DisplayName != grafanaOrganization.Spec.DisplayName {
-		logger.Info("updating orgID/displayName in the grafanaOrganization status")
+		logger.Info("updating grafanaOrganization status")
 		grafanaOrganization.Status.OrgID = updatedID
 		grafanaOrganization.Status.DisplayName = grafanaOrganization.Spec.DisplayName
 
@@ -214,7 +214,7 @@ func (r GrafanaOrganizationReconciler) reconcileCreate(ctx context.Context, graf
 			return ctrl.Result{}, fmt.Errorf("failed to update grafanaOrganization status: %w", err)
 		}
 		orgStatus = metrics.OrgStatusActive
-		logger.Info("updated orgID/displayName in the grafanaOrganization status")
+		logger.Info("updated grafanaOrganization status")
 	}
 
 	// Collect all errors to ensure all independent tasks have a chance to run

--- a/internal/controller/grafanaorganization_controller.go
+++ b/internal/controller/grafanaorganization_controller.go
@@ -190,8 +190,10 @@ func (r GrafanaOrganizationReconciler) reconcileCreate(ctx context.Context, graf
 	// Convert to domain object
 	organization := r.organizationMapper.FromGrafanaOrganization(grafanaOrganization)
 
-	// Create or update the grafana organization
-	updatedID, err := grafanaService.ConfigureOrganization(ctx, organization)
+	// Create or update the grafana organization. Status.DisplayName is the last name we
+	// successfully applied; the Grafana service uses it to distinguish a CR rename from
+	// a stale orgID pointing to someone else's org.
+	updatedID, err := grafanaService.ConfigureOrganization(ctx, organization, grafanaOrganization.Status.DisplayName)
 	if err != nil {
 		// Set error status and update metric before returning
 		orgStatus = metrics.OrgStatusError
@@ -200,9 +202,10 @@ func (r GrafanaOrganizationReconciler) reconcileCreate(ctx context.Context, graf
 	}
 
 	// Update CR status if anything was changed
-	if grafanaOrganization.Status.OrgID != updatedID {
-		logger.Info("updating orgID in the grafanaOrganization status")
+	if grafanaOrganization.Status.OrgID != updatedID || grafanaOrganization.Status.DisplayName != grafanaOrganization.Spec.DisplayName {
+		logger.Info("updating orgID/displayName in the grafanaOrganization status")
 		grafanaOrganization.Status.OrgID = updatedID
+		grafanaOrganization.Status.DisplayName = grafanaOrganization.Spec.DisplayName
 
 		err = r.Client.Status().Update(ctx, grafanaOrganization)
 		if err != nil {
@@ -211,7 +214,7 @@ func (r GrafanaOrganizationReconciler) reconcileCreate(ctx context.Context, graf
 			return ctrl.Result{}, fmt.Errorf("failed to update grafanaOrganization status: %w", err)
 		}
 		orgStatus = metrics.OrgStatusActive
-		logger.Info("updated orgID in the grafanaOrganization status")
+		logger.Info("updated orgID/displayName in the grafanaOrganization status")
 	}
 
 	// Collect all errors to ensure all independent tasks have a chance to run

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -14,57 +14,70 @@ import (
 	"github.com/giantswarm/observability-operator/pkg/domain/organization"
 )
 
-// UpsertOrganization creates or updates an organization in Grafana based on the provided domain organization.
-func (s *Service) UpsertOrganization(ctx context.Context, org *organization.Organization) error {
+// UpsertOrganization reconciles the Grafana organization described by org with Grafana's current state.
+//
+// previousName is the last display name this CR successfully applied to its Grafana organization
+// (typically GrafanaOrganization.Status.DisplayName). It lets the reconciler tell apart:
+//
+//   - a CR rename: Grafana still has the org at org.ID() under previousName → rename it to org.Name().
+//   - a stale cached orgID: the org at org.ID() has a different name (and that name is not what we
+//     last wrote there), so it now belongs to someone else (e.g., Grafana's DB was reset and the ID
+//     got reassigned to another CR). We must not rename it; create a new org instead.
+//
+// Pass an empty previousName for a first-time reconcile. In that case a mismatched current name
+// is always treated as a collision (safer than assuming ownership).
+//
+// On success org.ID() is set to the current Grafana org ID.
+func (s *Service) UpsertOrganization(ctx context.Context, org *organization.Organization, previousName string) error {
 	logger := log.FromContext(ctx)
 	logger.Info("upserting organization")
 
-	// Get the current organization stored in Grafana
-	currentOrg, err := s.findOrgByID(org.ID())
-	if err != nil {
-		if errors.Is(err, organization.ErrOrganizationNotFound) {
-			foundOrgByName, err := s.FindOrgByName(org.Name())
-			if err == nil && foundOrgByName != nil {
-				// If the organization does not exist in Grafana, but we found it by name, we can use that ID.
-				logger.Info("found organization with the same name", "name", foundOrgByName.Name(), "id", foundOrgByName.ID())
-				org.SetID(foundOrgByName.ID())
-				return nil
-			}
-
-			logger.Info("organization name not found, creating")
-
-			// If organization does not exist in Grafana, create it
-			createdOrg, err := s.grafanaClient.Orgs().CreateOrg(&models.CreateOrgCommand{
-				Name: org.Name(),
-			})
-			if err != nil {
-				return fmt.Errorf("failed to create organization: %w", err)
-			}
-			logger.Info("created organization")
-
-			org.SetID(*createdOrg.Payload.OrgID)
-			return nil
-		}
-
-		return fmt.Errorf("failed to find organization with ID %d: %w", org.ID(), err)
+	// Prefer matching by name. If Grafana already has an org with our desired display name,
+	// adopt its ID — this handles first reconcile, a CR re-creation, and the case where
+	// Grafana's DB was reset and existing IDs no longer match status.orgID.
+	foundByName, err := s.FindOrgByName(org.Name())
+	if err != nil && !errors.Is(err, organization.ErrOrganizationNotFound) {
+		return fmt.Errorf("failed to look up organization by name: %w", err)
 	}
-
-	// If both name matches, there is nothing to do.
-	if currentOrg.Name() == org.Name() {
-		logger.Info("the organization already exists in Grafana and does not need to be updated.")
+	if foundByName != nil {
+		if org.ID() != foundByName.ID() {
+			logger.Info("adopting existing Grafana organization matching display name",
+				"name", foundByName.Name(), "newID", foundByName.ID(), "previousID", org.ID())
+		}
+		org.SetID(foundByName.ID())
 		return nil
 	}
 
-	// if the name of the CR is different from the name of the org in Grafana, update the name of the org in Grafana using the CR's display name.
-	_, err = s.grafanaClient.Orgs().UpdateOrg(org.ID(), &models.UpdateOrgForm{
-		Name: org.Name(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to update organization name: %w", err)
+	// No org with our desired name exists. If we have a cached ID, check whether the
+	// org still sitting at that ID is the one we previously owned (rename case) or a
+	// different one (stale-ID / collision case).
+	if org.ID() > 0 {
+		currentOrg, err := s.findOrgByID(org.ID())
+		switch {
+		case err == nil:
+			if previousName != "" && currentOrg.Name() == previousName {
+				logger.Info("renaming organization", "id", org.ID(), "from", currentOrg.Name(), "to", org.Name())
+				if _, err := s.grafanaClient.Orgs().UpdateOrg(org.ID(), &models.UpdateOrgForm{Name: org.Name()}); err != nil {
+					return fmt.Errorf("failed to update organization name: %w", err)
+				}
+				return nil
+			}
+			logger.Info("cached orgID points to an organization we no longer own; creating a new one",
+				"staleID", org.ID(), "currentName", currentOrg.Name(), "previousName", previousName)
+			// fall through to CreateOrg
+		case errors.Is(err, organization.ErrOrganizationNotFound):
+			// cached ID is gone; fall through to CreateOrg
+		default:
+			return fmt.Errorf("failed to find organization with ID %d: %w", org.ID(), err)
+		}
 	}
 
-	logger.Info("updated organization")
-
+	logger.Info("creating organization", "name", org.Name())
+	createdOrg, err := s.grafanaClient.Orgs().CreateOrg(&models.CreateOrgCommand{Name: org.Name()})
+	if err != nil {
+		return fmt.Errorf("failed to create organization: %w", err)
+	}
+	org.SetID(*createdOrg.Payload.OrgID)
 	return nil
 }
 
@@ -104,10 +117,15 @@ func isNotFound(err error) bool {
 	return false
 }
 
-// FindOrgByName is a wrapper function used to find a Grafana organization by its name
+// FindOrgByName is a wrapper function used to find a Grafana organization by its name.
+// It returns organization.ErrOrganizationNotFound (wrapped) when Grafana returns 404,
+// letting callers distinguish a missing organization from other API failures.
 func (s *Service) FindOrgByName(name string) (*organization.Organization, error) {
 	org, err := s.grafanaClient.Orgs().GetOrgByName(name)
 	if err != nil {
+		if isNotFound(err) {
+			return nil, fmt.Errorf("%w: %w", organization.ErrOrganizationNotFound, err)
+		}
 		return nil, fmt.Errorf("failed to get organization by name: %w", err)
 	}
 

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -53,8 +53,13 @@ func (s *Service) UpsertOrganization(ctx context.Context, org *organization.Orga
 	// different one (stale-ID / collision case).
 	if org.ID() > 0 {
 		currentOrg, err := s.findOrgByID(org.ID())
-		switch {
-		case err == nil:
+
+		if err != nil && !errors.Is(err, organization.ErrOrganizationNotFound) {
+			return fmt.Errorf("Error when trying to find organization with ID %d: %w", org.ID(), err)
+		}
+		// If err is ErrOrganizationNotFound, we fall through to CreateOrg below.
+
+		if currentOrg != nil {
 			if previousName != "" && currentOrg.Name() == previousName {
 				logger.Info("renaming organization", "id", org.ID(), "from", currentOrg.Name(), "to", org.Name())
 				if _, err := s.grafanaClient.Orgs().UpdateOrg(org.ID(), &models.UpdateOrgForm{Name: org.Name()}); err != nil {
@@ -64,11 +69,6 @@ func (s *Service) UpsertOrganization(ctx context.Context, org *organization.Orga
 			}
 			logger.Info("cached orgID points to an organization we no longer own; creating a new one",
 				"staleID", org.ID(), "currentName", currentOrg.Name(), "previousName", previousName)
-			// fall through to CreateOrg
-		case errors.Is(err, organization.ErrOrganizationNotFound):
-			// cached ID is gone; fall through to CreateOrg
-		default:
-			return fmt.Errorf("failed to find organization with ID %d: %w", org.ID(), err)
 		}
 	}
 

--- a/pkg/grafana/grafana_test.go
+++ b/pkg/grafana/grafana_test.go
@@ -1,0 +1,198 @@
+package grafana
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+
+	goruntime "github.com/go-openapi/runtime"
+	"github.com/grafana/grafana-openapi-client-go/client/orgs"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/giantswarm/observability-operator/pkg/domain/organization"
+	"github.com/giantswarm/observability-operator/pkg/grafana/client/mocks"
+)
+
+func notFoundErr() error {
+	return goruntime.NewAPIError("not found", nil, http.StatusNotFound)
+}
+
+func int64Ptr(v int64) *int64 { return &v }
+
+func newOrg(id int64, name string) *organization.Organization {
+	return organization.New(id, name, nil, nil, nil, nil)
+}
+
+func TestUpsertOrganization_AdoptsByName(t *testing.T) {
+	// Grafana already has an org with our display name at ID 7 — even though our
+	// cached status.orgID is stale (2). We should adopt ID 7 and touch nothing else.
+	mockClient := &mocks.MockGrafanaClient{}
+	mockOrgs := &mocks.MockOrgsClient{}
+	mockClient.On("Orgs").Return(mockOrgs)
+
+	mockOrgs.On("GetOrgByName", "Giant Swarm").Return(&orgs.GetOrgByNameOK{
+		Payload: &models.OrgDetailsDTO{ID: 7, Name: "Giant Swarm"},
+	}, nil)
+
+	svc := newTestService(mockClient)
+	org := newOrg(2, "Giant Swarm")
+
+	err := svc.UpsertOrganization(context.Background(), org, "something-stale")
+	require.NoError(t, err)
+	require.Equal(t, int64(7), org.ID())
+
+	mockOrgs.AssertExpectations(t)
+}
+
+func TestUpsertOrganization_CreatesWhenNoCachedIDAndNoNameMatch(t *testing.T) {
+	mockClient := &mocks.MockGrafanaClient{}
+	mockOrgs := &mocks.MockOrgsClient{}
+	mockClient.On("Orgs").Return(mockOrgs)
+
+	mockOrgs.On("GetOrgByName", "Giant Swarm").Return(nil, notFoundErr())
+	mockOrgs.On("CreateOrg", mock.MatchedBy(func(cmd *models.CreateOrgCommand) bool {
+		return cmd.Name == "Giant Swarm"
+	})).Return(&orgs.CreateOrgOK{
+		Payload: &models.CreateOrgOKBody{OrgID: int64Ptr(42)},
+	}, nil)
+
+	svc := newTestService(mockClient)
+	org := newOrg(0, "Giant Swarm")
+
+	err := svc.UpsertOrganization(context.Background(), org, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(42), org.ID())
+
+	mockOrgs.AssertExpectations(t)
+}
+
+func TestUpsertOrganization_RenamesInPlaceWhenPreviousNameMatches(t *testing.T) {
+	// User renamed the CR: spec.displayName changed from "Old" to "New".
+	// Grafana has org 2 = "Old" (still ours). previousName="Old" unlocks rename.
+	mockClient := &mocks.MockGrafanaClient{}
+	mockOrgs := &mocks.MockOrgsClient{}
+	mockClient.On("Orgs").Return(mockOrgs)
+
+	mockOrgs.On("GetOrgByName", "New").Return(nil, notFoundErr())
+	mockOrgs.On("GetOrgByID", int64(2)).Return(&orgs.GetOrgByIDOK{
+		Payload: &models.OrgDetailsDTO{ID: 2, Name: "Old"},
+	}, nil)
+	mockOrgs.On("UpdateOrg", int64(2), mock.MatchedBy(func(cmd *models.UpdateOrgForm) bool {
+		return cmd.Name == "New"
+	})).Return(&orgs.UpdateOrgOK{}, nil)
+
+	svc := newTestService(mockClient)
+	org := newOrg(2, "New")
+
+	err := svc.UpsertOrganization(context.Background(), org, "Old")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), org.ID())
+
+	mockOrgs.AssertExpectations(t)
+}
+
+func TestUpsertOrganization_StaleIDCollision_CreatesFreshInsteadOfClobbering(t *testing.T) {
+	// Two CRs ended up with status.orgID=2 after a Grafana DB reset. The first CR
+	// re-created "Giant Swarm" at ID=2; now this second CR reconciles with a stale
+	// orgID=2 but displayName "Hello World". Grafana has ID 2 = "Giant Swarm"
+	// (owned by the other CR), and status.displayName on this CR was "Hello World"
+	// — so the name at our cached ID is NOT what we last wrote there. The fix
+	// must NOT rename org 2 (that would clobber the sibling CR) and instead create
+	// a fresh org for us.
+	mockClient := &mocks.MockGrafanaClient{}
+	mockOrgs := &mocks.MockOrgsClient{}
+	mockClient.On("Orgs").Return(mockOrgs)
+
+	mockOrgs.On("GetOrgByName", "Hello World").Return(nil, notFoundErr())
+	mockOrgs.On("GetOrgByID", int64(2)).Return(&orgs.GetOrgByIDOK{
+		Payload: &models.OrgDetailsDTO{ID: 2, Name: "Giant Swarm"},
+	}, nil)
+	mockOrgs.On("CreateOrg", mock.MatchedBy(func(cmd *models.CreateOrgCommand) bool {
+		return cmd.Name == "Hello World"
+	})).Return(&orgs.CreateOrgOK{
+		Payload: &models.CreateOrgOKBody{OrgID: int64Ptr(99)},
+	}, nil)
+
+	svc := newTestService(mockClient)
+	org := newOrg(2, "Hello World")
+
+	err := svc.UpsertOrganization(context.Background(), org, "Hello World")
+	require.NoError(t, err)
+	require.Equal(t, int64(99), org.ID())
+
+	// Critically: UpdateOrg must NOT have been called on the sibling's org.
+	mockOrgs.AssertNotCalled(t, "UpdateOrg", mock.Anything, mock.Anything)
+	mockOrgs.AssertExpectations(t)
+}
+
+func TestUpsertOrganization_EmptyPreviousNameTreatsIDMismatchAsCollision(t *testing.T) {
+	// First-ever reconcile after adding status.displayName: previousName is empty.
+	// Even though status.orgID=2 is set, we refuse to rename whatever sits there
+	// because we can't prove it was ours. Create fresh.
+	mockClient := &mocks.MockGrafanaClient{}
+	mockOrgs := &mocks.MockOrgsClient{}
+	mockClient.On("Orgs").Return(mockOrgs)
+
+	mockOrgs.On("GetOrgByName", "Giant Swarm").Return(nil, notFoundErr())
+	mockOrgs.On("GetOrgByID", int64(2)).Return(&orgs.GetOrgByIDOK{
+		Payload: &models.OrgDetailsDTO{ID: 2, Name: "Something Else"},
+	}, nil)
+	mockOrgs.On("CreateOrg", mock.Anything).Return(&orgs.CreateOrgOK{
+		Payload: &models.CreateOrgOKBody{OrgID: int64Ptr(55)},
+	}, nil)
+
+	svc := newTestService(mockClient)
+	org := newOrg(2, "Giant Swarm")
+
+	err := svc.UpsertOrganization(context.Background(), org, "")
+	require.NoError(t, err)
+	require.Equal(t, int64(55), org.ID())
+
+	mockOrgs.AssertNotCalled(t, "UpdateOrg", mock.Anything, mock.Anything)
+	mockOrgs.AssertExpectations(t)
+}
+
+func TestUpsertOrganization_CachedIDGone_CreatesFresh(t *testing.T) {
+	// Grafana's DB was reset: our cached ID and the name both 404. Create fresh.
+	mockClient := &mocks.MockGrafanaClient{}
+	mockOrgs := &mocks.MockOrgsClient{}
+	mockClient.On("Orgs").Return(mockOrgs)
+
+	mockOrgs.On("GetOrgByName", "Giant Swarm").Return(nil, notFoundErr())
+	mockOrgs.On("GetOrgByID", int64(2)).Return(nil, notFoundErr())
+	mockOrgs.On("CreateOrg", mock.Anything).Return(&orgs.CreateOrgOK{
+		Payload: &models.CreateOrgOKBody{OrgID: int64Ptr(2)},
+	}, nil)
+
+	svc := newTestService(mockClient)
+	org := newOrg(2, "Giant Swarm")
+
+	err := svc.UpsertOrganization(context.Background(), org, "Giant Swarm")
+	require.NoError(t, err)
+	require.Equal(t, int64(2), org.ID())
+
+	mockOrgs.AssertExpectations(t)
+}
+
+func TestUpsertOrganization_FindByNameTransientError_Propagates(t *testing.T) {
+	// Any non-404 error while looking up by name must surface — we must NOT
+	// silently create a duplicate org on a transient Grafana hiccup.
+	mockClient := &mocks.MockGrafanaClient{}
+	mockOrgs := &mocks.MockOrgsClient{}
+	mockClient.On("Orgs").Return(mockOrgs)
+
+	mockOrgs.On("GetOrgByName", "Giant Swarm").Return(nil, errors.New("connection refused"))
+
+	svc := newTestService(mockClient)
+	org := newOrg(2, "Giant Swarm")
+
+	err := svc.UpsertOrganization(context.Background(), org, "Giant Swarm")
+	require.Error(t, err)
+
+	mockOrgs.AssertNotCalled(t, "CreateOrg", mock.Anything)
+	mockOrgs.AssertNotCalled(t, "UpdateOrg", mock.Anything, mock.Anything)
+	mockOrgs.AssertExpectations(t)
+}

--- a/pkg/grafana/organization.go
+++ b/pkg/grafana/organization.go
@@ -23,8 +23,10 @@ func (s *Service) DeleteOrganization(ctx context.Context, organization *organiza
 }
 
 // ConfigureOrganization creates or updates the organization in Grafana and returns the organization ID.
-func (s *Service) ConfigureOrganization(ctx context.Context, organization *organization.Organization) (int64, error) {
-	err := s.UpsertOrganization(ctx, organization)
+// previousName is the last display name the caller persisted for this organization (typically
+// GrafanaOrganization.Status.DisplayName); see UpsertOrganization for how it is used.
+func (s *Service) ConfigureOrganization(ctx context.Context, organization *organization.Organization, previousName string) (int64, error) {
+	err := s.UpsertOrganization(ctx, organization, previousName)
 	if err != nil {
 		metrics.GrafanaAPIErrors.WithLabelValues(metrics.OpConfigureOrg).Inc()
 		return -1, fmt.Errorf("ConfigureOrganization: failed to configure organization: %w", err)


### PR DESCRIPTION
### What this PR does / why we need it

`GrafanaOrganization` reconciler no longer renames another CR's Grafana organization when two CRs end up sharing the same `status.orgID` (e.g., after a Grafana DB reset that reassigns IDs).
`UpsertOrganization` now prefers lookup by display name and only renames an existing Grafana org when `status.displayName` matches what is currently at the cached ID — otherwise it creates a fresh org.
Added `status.displayName` on `GrafanaOrganization` to make this distinction possible.

This solves some conflicts when restarting from a clean grafana database (usually happening on test clusters).

### Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs under `docs/` and `README.md` updated if the change affects operator behaviour, feature flags, CRD fields, exposed metrics, or configuration
