### PR TITLE
test: dry-run multi-arch build with architect-orb v8.1 dev (DO NOT MERGE)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:dffc167256943ddce13df3debe59d3ea11f1d4c9
+  architect: giantswarm/architect@dev:eaebab48a563ebc8db6cc2b3ca2297c3e46153ba
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:feat-v8.1-multiarch-simplification
+  architect: giantswarm/architect@dev:537df66c95f79fe6699d2f8b5f3d9622e3bc8416
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:537df66c95f79fe6699d2f8b5f3d9622e3bc8416
+  architect: giantswarm/architect@dev:a4d8e1e21a163ffcb6e46d85aab186b224de7de5
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:71b3d35d5c85a58f049977b40dee5232aac9c8cc
+  architect: giantswarm/architect@dev:8210a03f7ebfc85e9dd84ba8a63d0e347fc4073b
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@8.0.0
+  architect: giantswarm/architect@dev:feat-v8.1-multiarch-simplification
 
 jobs:
   go-tests:
@@ -60,6 +60,7 @@ workflows:
         - validate-alertmanager-config
         path: ./cmd
         binary: observability-operator
+        architectures: "linux/amd64,linux/arm64"
         filters:
           tags:
             only: /^v.*/
@@ -69,6 +70,7 @@ workflows:
         name: push-to-registries
         requires:
         - go-build
+        multiarch: true
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:a970ccccc2190b99aceae523bffadf97a8c0ef1b
+  architect: giantswarm/architect@dev:701bf81566d6723ba9a1993f19148a66df628540
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:701bf81566d6723ba9a1993f19148a66df628540
+  architect: giantswarm/architect@dev:71b3d35d5c85a58f049977b40dee5232aac9c8cc
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:8db824b2b666b886099c49dce6942b5b0a4d3deb
+  architect: giantswarm/architect@dev:dffc167256943ddce13df3debe59d3ea11f1d4c9
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:767c375ecec2218f2db54a477f8c78bfcb1ea12f
+  architect: giantswarm/architect@dev:e24dce94bc0180684adc76ed19d8b5d0a10d88a6
 
 jobs:
   go-tests:
@@ -70,7 +70,6 @@ workflows:
         name: push-to-registries
         requires:
         - go-build
-        multiarch: true
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:a4d8e1e21a163ffcb6e46d85aab186b224de7de5
+  architect: giantswarm/architect@dev:8db824b2b666b886099c49dce6942b5b0a4d3deb
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:e24dce94bc0180684adc76ed19d8b5d0a10d88a6
+  architect: giantswarm/architect@dev:041d2e89f184ed730275b2550bcd69d62352abd3
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,6 +54,7 @@ workflows:
             only: /^v.*/
 
     - architect/go-build:
+        context: architect
         name: go-build
         requires:
         - go-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:eaebab48a563ebc8db6cc2b3ca2297c3e46153ba
+  architect: giantswarm/architect@dev:767c375ecec2218f2db54a477f8c78bfcb1ea12f
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:041d2e89f184ed730275b2550bcd69d62352abd3
+  architect: giantswarm/architect@dev:a970ccccc2190b99aceae523bffadf97a8c0ef1b
 
 jobs:
   go-tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@dev:8210a03f7ebfc85e9dd84ba8a63d0e347fc4073b
+  architect: giantswarm/architect@dev:62276e55b72762d5b223f9f24e4c0576c7055c00
 
 jobs:
   go-tests:
@@ -105,3 +105,17 @@ workflows:
             - main
         requires:
         - push-to-app-catalog
+
+    # Upload signed Go binaries (and their cosign .bundle siblings) to the GitHub
+    # release for the tag. Tag-only: never runs on a branch push.
+    - architect/upload-release-assets:
+        context: architect
+        name: upload-release-assets
+        binary: observability-operator
+        requires:
+        - go-build
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Build and publish a multi-architecture container image for `linux/amd64` and `linux/arm64`.
+
 ### Changed
 
 - Bump `github.com/grafana/grafana-openapi-client-go` to `v0.0.0-20260430175825-547a3b5a00a5`. The new release makes `WithOrgID` non-mutating (returns a clone) and stops mutating the package-level `http.DefaultTransport` — the latter was a real data race in the previous transport setup.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 # Use distroless as minimal base image to package the observability-operator binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 WORKDIR /
 
-ADD observability-operator observability-operator
+ADD observability-operator-linux-${TARGETARCH} observability-operator
 
 USER 65532:65532
 


### PR DESCRIPTION
**Test branch — do not merge.** Validates [architect-orb#736](https://github.com/giantswarm/architect-orb/pull/736) (v8.1 multi-arch simplification) end-to-end against a real consumer.

### Changes

\`\`\`diff
 # .circleci/config.yml
 orbs:
-  architect: giantswarm/architect@8.0.0
+  architect: giantswarm/architect@dev:feat-v8.1-multiarch-simplification
...
     - architect/go-build:
         path: ./cmd
         binary: observability-operator
+        architectures: "linux/amd64,linux/arm64"
...
     - architect/push-to-registries:
+        multiarch: true

 # Dockerfile
 FROM gcr.io/distroless/static:nonroot
+ARG TARGETARCH
 WORKDIR /
-ADD observability-operator observability-operator
+ADD observability-operator-linux-\${TARGETARCH} observability-operator
\`\`\`

### What to look for in CI

| Job | Expected log line(s) |
|---|---|
| \`go-build\` | \`Building observability-operator-linux-amd64...\` AND \`Building observability-operator-linux-arm64...\` |
| \`push-to-registries\` | \`Building for platforms: linux/amd64,linux/arm64\` |
| \`push-to-registries\` (buildx output) | Two manifest digests written, one per platform |

### Validation after CI passes

\`\`\`bash
# Manifest contains both architectures
docker manifest inspect gsoci.azurecr.io/giantswarm/observability-operator:<tag> | jq '.manifests[].platform'

# Run amd64 image
docker run --rm --platform=linux/amd64 gsoci.azurecr.io/giantswarm/observability-operator:<tag> --help

# Run arm64 image (needs binfmt on amd64 host; native on arm64 host)
docker run --rm --platform=linux/arm64 gsoci.azurecr.io/giantswarm/observability-operator:<tag> --help

# Inspect binary inside arm64 image
CID=\$(docker create --platform=linux/arm64 gsoci.azurecr.io/giantswarm/observability-operator:<tag>)
docker cp \$CID:/observability-operator ./bin-arm64
docker rm \$CID
file ./bin-arm64    # expect: ELF 64-bit LSB executable, ARM aarch64
\`\`\`

### Cleanup

After validation, close this PR without merging. The orb dev version (\`@dev:...\`) expires after 90 days; for the real cutover, wait until v8.1.0 is tagged and open a fresh PR pinned to \`@8.1.0\`.