### PR TITLE
Fix make verify-generate ? ... or not

### DIFF
--- a/Makefile.kubebuilder.mk
+++ b/Makefile.kubebuilder.mk
@@ -92,7 +92,7 @@ generate-all: generate manifests ## Generate everything (code + manifests)
 # ==================================================================================
 
 .PHONY: generate-deepcopy
-generate-deepcopy: $(CONTROLLER_GEN) ## Generate deepcopy methods for API types
+generate-deepcopy: $(CONTROLLER_GEN) $(GOIMPORTS) ## Generate deepcopy methods for API types
 	@$(log_build) "Generating deepcopy methods"
 	@if [ ! -d "$(API_DIR)" ]; then \
 		$(log_warn) "API directory $(API_DIR) not found, skipping deepcopy generation"; \

--- a/Makefile.kubebuilder.mk
+++ b/Makefile.kubebuilder.mk
@@ -27,6 +27,8 @@ ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api 2>/dev/
 # Code quality and development tool versions
 GOLANGCI_LINT_VERSION ?= v2.4.0
 GINKGO_VERSION ?= $(shell go list -m -f "{{ .Version }}" github.com/onsi/ginkgo/v2)
+GOIMPORTS_VERSION ?= v0.45.0
+GOIMPORTS_LOCAL_PREFIX ?= github.com/giantswarm/observability-operator
 
 # Directories
 API_DIR := $(shell [ -d api ] && echo api || echo pkg/apis)
@@ -45,6 +47,7 @@ KUSTOMIZE ?= $(LOCALBIN)/kustomize
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 GINKGO ?= $(LOCALBIN)/ginkgo
+GOIMPORTS ?= $(LOCALBIN)/goimports
 
 # Generation options
 BOILERPLATE := $(SCRIPTS_DIR)/boilerplate.go.txt
@@ -99,6 +102,8 @@ generate-deepcopy: $(CONTROLLER_GEN) ## Generate deepcopy methods for API types
 		$(log_warn) "Failed to generate deepcopy methods"; \
 		exit 1; \
 	}
+	# Formatting with goimports ensure Go imports are in the same format expected by the 'ci/circleci: go-build' CI job.
+	@$(GOIMPORTS) -local $(GOIMPORTS_LOCAL_PREFIX) -w .
 	@$(log_info) "Deepcopy generation completed"
 
 .PHONY: generate-client
@@ -275,8 +280,13 @@ ginkgo: $(GINKGO) ## Download ginkgo locally if necessary.
 $(GINKGO): $(LOCALBIN)
 	$(call go-install-tool,$(GINKGO),github.com/onsi/ginkgo/v2/ginkgo,$(GINKGO_VERSION))
 
+.PHONY: goimports
+goimports: $(GOIMPORTS) ## Download goimports locally if necessary.
+$(GOIMPORTS): $(LOCALBIN)
+	$(call go-install-tool,$(GOIMPORTS),golang.org/x/tools/cmd/goimports,$(GOIMPORTS_VERSION))
+
 .PHONY: install-tools
-install-tools: controller-gen kustomize envtest golangci-lint ginkgo ## Install all development tools
+install-tools: controller-gen kustomize envtest golangci-lint ginkgo goimports ## Install all development tools
 	@$(log_info) "All development tools installed successfully"
 
 .PHONY: update-tools
@@ -387,6 +397,7 @@ help-kubebuilder: ## Show help for Kubebuilder targets
 	@echo "    setup-envtest        Setup envtest binaries for testing"
 	@echo "    golangci-lint        Install golangci-lint linting tool"
 	@echo "    ginkgo               Install Ginkgo testing framework"
+	@echo "    goimports            Install goimports tool"
 	@echo ""
 	@echo "  $(GEN_COLOR)Cleanup:$(NO_COLOR)"
 	@echo "    clean-generated      Clean generated code files"

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )


### PR DESCRIPTION
This PR fixes the `ci/circleci: verify-generate` job in order to produce the same Go imports output as expected by the `ci/circleci: go-build` job.

### Problem

`ci/circleci: go-build` expect Go imports to be sorted using `goimports`.

<img width="930" height="665" alt="image" src="https://github.com/user-attachments/assets/07a2e10d-a311-4847-a037-e063ae1f15a6" />

[source](https://app.circleci.com/pipelines/github/giantswarm/observability-operator/5251/workflows/dbf6c231-39e8-4d61-9c32-bf2fac8674e3/jobs/30126)


But `make generate-all` does generate a Go import format which does not satisfy the expected `goimports` format

```diff
$ make generate-all
🔨 Generating deepcopy methods
ℹ️  Deepcopy generation completed
🔨 Generating CRDs with enhanced validation
... truncated output ...
ℹ️  Complete generation finished
$ git diff
diff --git a/api/v1alpha1/zz_generated.deepcopy.go b/api/v1alpha1/zz_generated.deepcopy.go
index 6149cef..e0b40da 100644
--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1

 import (
-       v1 "k8s.io/api/core/v1"
+       "k8s.io/api/core/v1"
        metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
        runtime "k8s.io/apimachinery/pkg/runtime"
 )
```

### Solution

This PR add a `goimports` command right after the generate-deepcopy happened.