### PR TITLE
disable streaming for tempo datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Tempo datasource: disable streaming for metrics and search queries (`streamingEnabled.metrics` and `streamingEnabled.search` now default to `false`).
 - Bump `github.com/grafana/grafana-openapi-client-go` to `v0.0.0-20260430175825-547a3b5a00a5`. The new release makes `WithOrgID` non-mutating (returns a clone) and stops mutating the package-level `http.DefaultTransport` — the latter was a real data race in the previous transport setup.
 - `GrafanaClient.WithOrgID` now returns a fresh client; `OrgID()` was removed from the interface. Service helpers (`ConfigureDashboard`, `DeleteDashboard`, `ConfigureDatasource`, `CleanupOrphanedFoldersForOrg`) thread the per-org client through `withinOrganization` instead of mutating shared state with a save/restore dance.
 - Upgrade Cluster API import from v1beta1 to v1beta2 (sigs.k8s.io/cluster-api/api/core/v1beta2).

--- a/pkg/grafana/datasources_default.go
+++ b/pkg/grafana/datasources_default.go
@@ -125,10 +125,10 @@ var (
 					"enabled": true,
 				},
 
-				// Streaming configuration for better performance with metrics
+				// Streaming is disabled for metrics and search queries.
 				"streamingEnabled": map[string]any{
-					"metrics": true,
-					"search":  true,
+					"metrics": false,
+					"search":  false,
 				},
 
 				// Traces to Logs correlation V2 - allows jumping from trace spans

--- a/pkg/grafana/datasources_test.go
+++ b/pkg/grafana/datasources_test.go
@@ -31,8 +31,8 @@ func TestDatasourceTempo(t *testing.T) {
 						"enabled": true,
 					},
 					"streamingEnabled": map[string]any{
-						"metrics": true,
-						"search":  true,
+						"metrics": false,
+						"search":  false,
 					},
 					"tracesToLogsV2": map[string]any{
 						"datasourceUid":      LokiDatasourceUID,


### PR DESCRIPTION
### What this PR does / why we need it

Towards https://github.com/giantswarm/giantswarm/issues/36664

Tempo currently does not support setting org-id with streaming enabled.
This is tracked upstream with https://github.com/grafana/grafana/issues/123923

The symptoms for us is grafana's "Drilldown" for Tempo does not work.

So, until the issue is fixed upstream, let's disable streaming.

### Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs under `docs/` and `README.md` updated if the change affects operator behaviour, feature flags, CRD fields, exposed metrics, or configuration
