### PR TITLE
feat: add support for Azure ASO (AKS) clusters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added support for Azure ASO (AKS) clusters.
+
 ## [0.69.0] - 2026-05-28
 
 ### Added
@@ -1216,4 +1220,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.3]: https://github.com/giantswarm/observability-operator/compare/v0.0.2...v0.0.3
 [0.0.2]: https://github.com/giantswarm/observability-operator/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/giantswarm/observability-operator/releases/tag/v0.0.1
-

--- a/pkg/common/types.go
+++ b/pkg/common/types.go
@@ -19,6 +19,9 @@ const (
 	AzureManagedClusterKind         = "AzureManagedCluster"
 	AzureManagedClusterKindProvider = "aks"
 
+	AzureASOManagedClusterKind         = "AzureASOManagedCluster"
+	AzureASOManagedClusterKindProvider = "aks"
+
 	VCDClusterKind         = "VCDCluster"
 	VCDClusterKindProvider = "cloud-director"
 
@@ -74,6 +77,8 @@ func GetClusterProvider(cluster *clusterv1.Cluster) (string, error) {
 		return AzureClusterKindProvider, nil
 	case AzureManagedClusterKind:
 		return AzureManagedClusterKindProvider, nil
+	case AzureASOManagedClusterKind:
+		return AzureASOManagedClusterKindProvider, nil
 	case VCDClusterKind:
 		return VCDClusterKindProvider, nil
 	case VSphereClusterKind:

--- a/pkg/config/cluster.go
+++ b/pkg/config/cluster.go
@@ -19,6 +19,9 @@ const (
 	AzureManagedClusterKind         = "AzureManagedCluster"
 	AzureManagedClusterKindProvider = "aks"
 
+	AzureASOManagedClusterKind         = "AzureASOManagedCluster"
+	AzureASOManagedClusterKindProvider = "aks"
+
 	VCDClusterKind         = "VCDCluster"
 	VCDClusterKindProvider = "cloud-director"
 
@@ -87,6 +90,8 @@ func (c ClusterConfig) GetClusterProvider(cluster *clusterv1.Cluster) (string, e
 		return AzureClusterKindProvider, nil
 	case AzureManagedClusterKind:
 		return AzureManagedClusterKindProvider, nil
+	case AzureASOManagedClusterKind:
+		return AzureASOManagedClusterKindProvider, nil
 	case VCDClusterKind:
 		return VCDClusterKindProvider, nil
 	case VSphereClusterKind:


### PR DESCRIPTION
### What this PR does / why we need it

Adds support for AKS clusters using the ASO CR variant.

Towards https://github.com/giantswarm/giantswarm/issues/36639

### Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [ ] Docs under `docs/` and `README.md` updated if the change affects operator behaviour, feature flags, CRD fields, exposed metrics, or configuration
