### PR TITLE
refactor: clean up dashboard controller logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Update dashboard controller log entries
+  - Simplify per dashboard logging
+  - Remove redundant log lines
+  - Remove started/finished log entries
+
 ## [0.70.0] - 2026-06-05
 
 ### Added

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -183,28 +183,30 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 	org := ""
 	// Process each dashboard
 	for _, dashboard := range dashboards {
-		org = dashboard.Organization() // org is the same for all dashboards in the same configmap, so we can just take it from the first one
+		// org is the same for all dashboards in the same configmap, so we can just take it from the first one
+		org = dashboard.Organization()
+
+		// Create a unique logger for the current dashboard
+		dl := logger.WithValues(
+			"uid", dashboard.UID(),
+			"organization", dashboard.Organization(),
+			"folder", dashboard.FolderPath(),
+		)
+
 		// Defensive validation: Ensure dashboards are valid even if webhook was bypassed
 		if validationErrors := dashboard.Validate(); len(validationErrors) > 0 {
-			logger.Error(nil, "dashboard validate failed - webhook may have been bypassed",
-				"uid", dashboard.UID(), "organization", dashboard.Organization(), "errors", validationErrors,
-				"configmap", dashboardConfigMap.Name, "namespace", dashboardConfigMap.Namespace)
+			dl.Error(nil, "dashboard validation failed during reconciliation - webhook may have been bypassed", "errors", validationErrors)
 			errs = append(errs, fmt.Errorf("dashboard validation failed for uid %s: %v", dashboard.UID(), validationErrors))
 			continue
 		}
 
-		logger.Info("Configuring dashboard", "uid", dashboard.UID(), "organization", dashboard.Organization())
 		err = grafanaService.ConfigureDashboard(ctx, dashboard)
 		if err != nil {
-			logger.Error(err, "dashboard configuration failed",
-				"uid", dashboard.UID(), "organization", dashboard.Organization(),
-				"configmap", dashboardConfigMap.Name, "namespace", dashboardConfigMap.Namespace)
-			errs = append(errs, fmt.Errorf("dashboard configuration failed for uid %s: %w", dashboard.UID(), err))
+			dl.Error(err, "failed to configure dashboard")
+			errs = append(errs, fmt.Errorf("failed to configure dashboard uid %s: %w", dashboard.UID(), err))
 			continue
 		}
-		logger.Info("dashboard configured in Grafana",
-			"uid", dashboard.UID(), "organization", dashboard.Organization(),
-			"configmap", dashboardConfigMap.Name, "namespace", dashboardConfigMap.Namespace)
+		dl.Info("dashboard configured in Grafana")
 	}
 
 	// If any errors occurred, combine them and return
@@ -225,6 +227,7 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 // reconcileDelete deletes the grafana dashboard.
 func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaService *grafana.Service, dashboardConfigMap *v1.ConfigMap) error {
 	logger := log.FromContext(ctx)
+
 	// We do not need to delete anything if there is no finalizer on the grafana dashboard
 	if !controllerutil.ContainsFinalizer(dashboardConfigMap, DashboardFinalizer) {
 		return nil
@@ -238,27 +241,30 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 	org := ""
 	// Process each dashboard: validate and delete in the same loop
 	for _, dash := range dashboards {
-		org = dash.Organization() // org is the same for all dashboards in the same configmap, so we can just take it from the first one
+		// org is the same for all dashboards in the same configmap, so we can just take it from the first one
+		org = dash.Organization()
+
+		// Create a unique logger for the current dashboard
+		dl := logger.WithValues(
+			"uid", dash.UID(),
+			"organization", dash.Organization(),
+			"folder", dash.FolderPath(),
+		)
+
 		// Defensive validation: Ensure dashboards are valid even if webhook was bypassed
 		if validationErrors := dash.Validate(); len(validationErrors) > 0 {
-			logger.Error(nil, "Dashboard validation failed during reconciliation - webhook may have been bypassed",
-				"dashboard", dash.UID(), "organization", dash.Organization(), "errors", validationErrors,
-				"configmap", dashboard.Name, "namespace", dashboard.Namespace)
+			dl.Error(nil, "dashboard validation failed during reconciliation - webhook may have been bypassed", "errors", validationErrors)
 			errs = append(errs, fmt.Errorf("dashboard validation failed for uid %s: %v", dash.UID(), validationErrors))
 			continue
 		}
 
 		err := grafanaService.DeleteDashboard(ctx, dash)
 		if err != nil {
-			logger.Error(err, "failed to delete dashboard",
-				"uid", dash.UID(), "organization", dash.Organization(),
-				"configmap", dashboard.Name, "namespace", dashboard.Namespace)
+			dl.Error(err, "failed to delete dashboard")
 			errs = append(errs, fmt.Errorf("failed to delete dashboard uid %s: %w", dash.UID(), err))
 			continue
 		}
-		logger.Info("dashboard deleted from Grafana",
-			"uid", dash.UID(), "organization", dash.Organization(),
-			"configmap", dashboard.Name, "namespace", dashboard.Namespace)
+		dl.Info("dashboard deleted from Grafana")
 	}
 
 	// If any errors occurred, combine them and return

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -67,11 +67,13 @@ func SetupDashboardReconciler(mgr manager.Manager, cfg config.Config, grafanaCli
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.0/pkg/reconcile
 func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	// Update logger with configmap name and namespace.
 	logger := log.FromContext(ctx).WithValues("configmap", req.NamespacedName)
 	ctx = log.IntoContext(ctx, logger)
 
-	dashboard := &v1.ConfigMap{}
-	err := r.Get(ctx, req.NamespacedName, dashboard)
+	// Read ConfigMap from Kubernetes API.
+	dashboardConfigMap := &v1.ConfigMap{}
+	err := r.Get(ctx, req.NamespacedName, dashboardConfigMap)
 	if err != nil {
 		if client.IgnoreNotFound(err) != nil {
 			return ctrl.Result{}, fmt.Errorf("failed to get dashboard configmap: %w", err)
@@ -80,6 +82,7 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	// Create a Grafana client.
 	grafanaAPI, err := r.grafanaClientGen.GenerateGrafanaClient(ctx, r.Client, r.grafanaURL)
 	if err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to generate Grafana client: %w", err)
@@ -87,13 +90,13 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	grafanaService := grafana.NewService(grafanaAPI, r.cfg)
 
-	// Handle deleted grafana dashboards
-	if !dashboard.DeletionTimestamp.IsZero() {
-		return ctrl.Result{}, r.reconcileDelete(ctx, grafanaService, dashboard)
+	// Handle dashboard deletion.
+	if !dashboardConfigMap.DeletionTimestamp.IsZero() {
+		return ctrl.Result{}, r.reconcileDelete(ctx, grafanaService, dashboardConfigMap)
 	}
 
-	// Handle non-deleted grafana dashboards
-	return ctrl.Result{}, r.reconcileCreate(ctx, grafanaService, dashboard)
+	// Handle dashboards creation and update.
+	return ctrl.Result{}, r.reconcileCreate(ctx, grafanaService, dashboardConfigMap)
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -220,15 +223,15 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 }
 
 // reconcileDelete deletes the grafana dashboard.
-func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaService *grafana.Service, dashboard *v1.ConfigMap) error {
+func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaService *grafana.Service, dashboardConfigMap *v1.ConfigMap) error {
 	logger := log.FromContext(ctx)
 	// We do not need to delete anything if there is no finalizer on the grafana dashboard
-	if !controllerutil.ContainsFinalizer(dashboard, DashboardFinalizer) {
+	if !controllerutil.ContainsFinalizer(dashboardConfigMap, DashboardFinalizer) {
 		return nil
 	}
 
-	// Convert ConfigMap to domain objects using mapper
-	dashboards := r.dashboardMapper.FromConfigMap(dashboard)
+	// Convert ConfigMap to dashboard domain objects using mapper
+	dashboards := r.dashboardMapper.FromConfigMap(dashboardConfigMap)
 
 	// Collect all errors to ensure all dashboards have a chance to be processed
 	var errs []error
@@ -271,7 +274,7 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 	}
 
 	// Finalizer handling needs to come last.
-	err := r.finalizerHelper.EnsureRemoved(ctx, dashboard)
+	err := r.finalizerHelper.EnsureRemoved(ctx, dashboardConfigMap)
 	if err != nil {
 		return fmt.Errorf("failed to remove finalizer: %w", err)
 	}

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -70,9 +70,6 @@ func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	logger := log.FromContext(ctx).WithValues("configmap", req.NamespacedName)
 	ctx = log.IntoContext(ctx, logger)
 
-	logger.Info("started reconciling Grafana dashboard ConfigMap")
-	defer logger.Info("finished reconciling Grafana dashboard ConfigMap")
-
 	dashboard := &v1.ConfigMap{}
 	err := r.Get(ctx, req.NamespacedName, dashboard)
 	if err != nil {

--- a/internal/controller/finalizer.go
+++ b/internal/controller/finalizer.go
@@ -51,6 +51,7 @@ func (fh FinalizerHelper) EnsureAdded(ctx context.Context, object client.Object)
 	}
 
 	logger.Info("added finalizer", "finalizer", fh.finalizer)
+
 	return true, nil
 }
 

--- a/pkg/grafana/dashboard.go
+++ b/pkg/grafana/dashboard.go
@@ -22,8 +22,6 @@ func (s *Service) ConfigureDashboard(ctx context.Context, dashboard *dashboard.D
 	}
 
 	err = s.withinOrganization(ctx, org, func(ctx context.Context, client grafanaclient.GrafanaClient) error {
-		logger := log.FromContext(ctx)
-
 		// Ensure folder hierarchy exists and get the leaf folder UID
 		folderUID, err := s.ensureFolderHierarchy(ctx, client, dashboard.FolderPath())
 		if err != nil {
@@ -59,8 +57,6 @@ func (s *Service) DeleteDashboard(ctx context.Context, dashboard *dashboard.Dash
 	}
 
 	err = s.withinOrganization(ctx, org, func(ctx context.Context, client grafanaclient.GrafanaClient) error {
-		logger := log.FromContext(ctx)
-
 		_, err := client.Dashboards().GetDashboardByUID(dashboard.UID())
 		if err != nil {
 			return fmt.Errorf("failed to get dashboard: %w", err)

--- a/pkg/grafana/dashboard.go
+++ b/pkg/grafana/dashboard.go
@@ -43,7 +43,6 @@ func (s *Service) ConfigureDashboard(ctx context.Context, dashboard *dashboard.D
 			return fmt.Errorf("failed to update dashboard: %w", err)
 		}
 
-		logger.Info("updated dashboard", "folderPath", dashboard.FolderPath(), "folderUID", folderUID)
 		return nil
 	})
 	if err != nil {
@@ -72,7 +71,6 @@ func (s *Service) DeleteDashboard(ctx context.Context, dashboard *dashboard.Dash
 			return fmt.Errorf("failed to delete dashboard: %w", err)
 		}
 
-		logger.Info("deleted dashboard")
 		return nil
 	})
 	if err != nil {

--- a/pkg/grafana/folder.go
+++ b/pkg/grafana/folder.go
@@ -111,11 +111,13 @@ func (s *Service) CleanupOrphanedFoldersForOrg(ctx context.Context, org *organiz
 				continue
 			}
 
-			logger.Info("deleting orphaned folder", "uid", f.UID, "title", f.Title)
 			_, err = client.Folders().DeleteFolder(folders.NewDeleteFolderParams().WithFolderUID(f.UID))
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to delete orphaned folder %q: %w", f.UID, err))
+				continue
 			}
+
+			logger.Info("deleted orphaned folder", "uid", f.UID, "title", f.Title)
 		}
 
 		return errors.Join(errs...)


### PR DESCRIPTION
Cleans up the dashboard controller log entries.

### `internal/controller/dashboard_controller.go`
- Build a per-dashboard logger (`dl`) carrying `uid`, `organization`, and `folder`, and use it for the per-dashboard log lines instead of repeating those key/values on every call.
- Remove the `started reconciling` / `finished reconciling` log entries.
- Drop the `Configuring dashboard` info line; reword the configure-error message to `failed to configure dashboard`.
- Rename the `dashboard` ConfigMap variable to `dashboardConfigMap` to disambiguate it from the dashboard domain objects iterated in the reconcile loops.

### `pkg/grafana/dashboard.go`
- Remove the redundant `updated dashboard` and `deleted dashboard` info lines (and the now-unused `logger` declarations they required).
