### PR TITLE
refactor: consolidate dashboard reconcile loops and enrich logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Simplify per dashboard logging
   - Remove redundant log lines
   - Remove started/finished log entries
+- Update dashboard validation webhook logs
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Simplify per dashboard logging
   - Remove redundant log lines
   - Remove started/finished log entries
-- Update dashboard validation webhook logs
+- Update dashboard validation webhook log entries
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Update dashboard controller log entries
-  - Simplify per dashboard logging
+- Improve log messages
+  - Normalize per dashboard logging (with uid, organization and folder keys)
   - Remove redundant log lines
   - Remove started/finished log entries
-- Update dashboard validation webhook log entries
+  - Add ConfigMap information in errors
+  - Extract common dashboard processing logic from `reconcileCreate` and `reconcileDelete`
 
 ### Fixed
 

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -175,7 +175,8 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 
 	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.ConfigureDashboard(ctx, dash); err != nil {
-			return fmt.Errorf("failed to configure dashboard: %w", err)
+			log.FromContext(ctx).Error(err, "failed to configure dashboard")
+			return fmt.Errorf("failed to configure dashboard uid %s: %w", dash.UID(), err)
 		}
 		log.FromContext(ctx).Info("dashboard configured in Grafana")
 		return nil
@@ -203,7 +204,8 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 
 	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.DeleteDashboard(ctx, dash); err != nil {
-			return fmt.Errorf("failed to delete dashboard: %w", err)
+			log.FromContext(ctx).Error(err, "failed to delete dashboard")
+			return fmt.Errorf("failed to delete dashboard uid %s: %w", dash.UID(), err)
 		}
 		log.FromContext(ctx).Info("dashboard deleted from Grafana")
 		return nil
@@ -233,9 +235,10 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 // shared by the dashboards (empty if the ConfigMap holds none) along with the
 // joined errors.
 //
-// Validation and error logging live here because controller-runtime's own error
-// logging is disabled (see Reconcile): this is the only place per-dashboard
-// failures get logged.
+// The op is responsible for logging its own success/failure with a specific
+// message, since controller-runtime's own error logging is disabled (see
+// Reconcile); the returned error exists only to drive requeue. Validation
+// failures are logged here as they short-circuit before op runs.
 func (r *DashboardReconciler) processDashboards(
 	ctx context.Context,
 	dashboardConfigMap *v1.ConfigMap,
@@ -265,8 +268,7 @@ func (r *DashboardReconciler) processDashboards(
 		}
 
 		if err := op(log.IntoContext(ctx, dl), dash); err != nil {
-			dl.Error(err, "failed to reconcile dashboard")
-			errs = append(errs, fmt.Errorf("uid %s: %w", dash.UID(), err))
+			errs = append(errs, err)
 		}
 	}
 

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -171,8 +171,7 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 
 	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.ConfigureDashboard(ctx, dash); err != nil {
-			log.FromContext(ctx).Error(err, "failed to configure dashboard")
-			return fmt.Errorf("failed to configure dashboard uid %s: %w", dash.UID(), err)
+			return fmt.Errorf("failed to configure dashboard uid=%s from configMap=%s/%s: %w", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
 		}
 		log.FromContext(ctx).Info("dashboard configured in Grafana")
 		return nil
@@ -200,8 +199,7 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 
 	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.DeleteDashboard(ctx, dash); err != nil {
-			log.FromContext(ctx).Error(err, "failed to delete dashboard")
-			return fmt.Errorf("failed to delete dashboard uid %s: %w", dash.UID(), err)
+			return fmt.Errorf("failed to delete dashboard uid=%s from configMap=%s/%s: %w", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
 		}
 		log.FromContext(ctx).Info("dashboard deleted from Grafana")
 		return nil
@@ -258,8 +256,7 @@ func (r *DashboardReconciler) processDashboards(
 
 		// Defensive validation: ensure dashboards are valid even if webhook was bypassed.
 		if validationErrors := dash.Validate(); len(validationErrors) > 0 {
-			dl.Error(nil, "dashboard validation failed during reconciliation - webhook may have been bypassed", "errors", validationErrors)
-			errs = append(errs, fmt.Errorf("dashboard validation failed for uid %s: %v", dash.UID(), validationErrors))
+			errs = append(errs, fmt.Errorf("dashboard validation failed - webhook may have been bypassed - for uid=%s from configMap=%s/%s: %v", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), validationErrors))
 			continue
 		}
 

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -68,10 +68,6 @@ func SetupDashboardReconciler(mgr manager.Manager, cfg config.Config, grafanaCli
 // For more details, check Reconcile and its Result here:
 // - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.16.0/pkg/reconcile
 func (r *DashboardReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	// Update logger with configmap name and namespace.
-	logger := log.FromContext(ctx).WithValues("configmap", req.NamespacedName)
-	ctx = log.IntoContext(ctx, logger)
-
 	// Read ConfigMap from Kubernetes API.
 	dashboardConfigMap := &v1.ConfigMap{}
 	err := r.Get(ctx, req.NamespacedName, dashboardConfigMap)

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -228,11 +228,6 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 // the remaining dashboards from being processed. It returns the organization
 // shared by the dashboards (empty if the ConfigMap holds none) along with the
 // joined errors.
-//
-// The op is responsible for logging its own success/failure with a specific
-// message, since controller-runtime's own error logging is disabled (see
-// Reconcile); the returned error exists only to drive requeue. Validation
-// failures are logged here as they short-circuit before op runs.
 func (r *DashboardReconciler) processDashboards(
 	ctx context.Context,
 	dashboardConfigMap *v1.ConfigMap,

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -24,6 +24,7 @@ import (
 	"github.com/giantswarm/observability-operator/internal/mapper"
 	"github.com/giantswarm/observability-operator/internal/predicates"
 	"github.com/giantswarm/observability-operator/pkg/config"
+	"github.com/giantswarm/observability-operator/pkg/domain/dashboard"
 	"github.com/giantswarm/observability-operator/pkg/domain/folder"
 	"github.com/giantswarm/observability-operator/pkg/grafana"
 	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
@@ -163,8 +164,6 @@ func (r *DashboardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // This function is also responsible for:
 // - Adding the finalizer to the configmap
 func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaService *grafana.Service, dashboardConfigMap *v1.ConfigMap) error {
-	logger := log.FromContext(ctx)
-
 	// Add finalizer first if not set to avoid the race condition between init and delete.
 	finalizerAdded, err := r.finalizerHelper.EnsureAdded(ctx, dashboardConfigMap)
 	if err != nil {
@@ -174,44 +173,15 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 		return nil
 	}
 
-	// Convert ConfigMap to domain objects using mapper
-	dashboards := r.dashboardMapper.FromConfigMap(dashboardConfigMap)
-
-	// Collect all errors to ensure all dashboards have a chance to be processed
-	var errs []error
-
-	org := ""
-	// Process each dashboard
-	for _, dashboard := range dashboards {
-		// org is the same for all dashboards in the same configmap, so we can just take it from the first one
-		org = dashboard.Organization()
-
-		// Create a unique logger for the current dashboard
-		dl := logger.WithValues(
-			"uid", dashboard.UID(),
-			"organization", dashboard.Organization(),
-			"folder", dashboard.FolderPath(),
-		)
-
-		// Defensive validation: Ensure dashboards are valid even if webhook was bypassed
-		if validationErrors := dashboard.Validate(); len(validationErrors) > 0 {
-			dl.Error(nil, "dashboard validation failed during reconciliation - webhook may have been bypassed", "errors", validationErrors)
-			errs = append(errs, fmt.Errorf("dashboard validation failed for uid %s: %v", dashboard.UID(), validationErrors))
-			continue
+	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
+		if err := grafanaService.ConfigureDashboard(ctx, dash); err != nil {
+			return fmt.Errorf("failed to configure dashboard: %w", err)
 		}
-
-		err = grafanaService.ConfigureDashboard(ctx, dashboard)
-		if err != nil {
-			dl.Error(err, "failed to configure dashboard")
-			errs = append(errs, fmt.Errorf("failed to configure dashboard uid %s: %w", dashboard.UID(), err))
-			continue
-		}
-		dl.Info("dashboard configured in Grafana")
-	}
-
-	// If any errors occurred, combine them and return
-	if len(errs) > 0 {
-		return errors.Join(errs...)
+		log.FromContext(ctx).Info("dashboard configured in Grafana")
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Cleanup orphaned folders after all dashboards are processed
@@ -226,50 +196,20 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 
 // reconcileDelete deletes the grafana dashboard.
 func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaService *grafana.Service, dashboardConfigMap *v1.ConfigMap) error {
-	logger := log.FromContext(ctx)
-
 	// We do not need to delete anything if there is no finalizer on the grafana dashboard
 	if !controllerutil.ContainsFinalizer(dashboardConfigMap, DashboardFinalizer) {
 		return nil
 	}
 
-	// Convert ConfigMap to dashboard domain objects using mapper
-	dashboards := r.dashboardMapper.FromConfigMap(dashboardConfigMap)
-
-	// Collect all errors to ensure all dashboards have a chance to be processed
-	var errs []error
-	org := ""
-	// Process each dashboard: validate and delete in the same loop
-	for _, dash := range dashboards {
-		// org is the same for all dashboards in the same configmap, so we can just take it from the first one
-		org = dash.Organization()
-
-		// Create a unique logger for the current dashboard
-		dl := logger.WithValues(
-			"uid", dash.UID(),
-			"organization", dash.Organization(),
-			"folder", dash.FolderPath(),
-		)
-
-		// Defensive validation: Ensure dashboards are valid even if webhook was bypassed
-		if validationErrors := dash.Validate(); len(validationErrors) > 0 {
-			dl.Error(nil, "dashboard validation failed during reconciliation - webhook may have been bypassed", "errors", validationErrors)
-			errs = append(errs, fmt.Errorf("dashboard validation failed for uid %s: %v", dash.UID(), validationErrors))
-			continue
+	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
+		if err := grafanaService.DeleteDashboard(ctx, dash); err != nil {
+			return fmt.Errorf("failed to delete dashboard: %w", err)
 		}
-
-		err := grafanaService.DeleteDashboard(ctx, dash)
-		if err != nil {
-			dl.Error(err, "failed to delete dashboard")
-			errs = append(errs, fmt.Errorf("failed to delete dashboard uid %s: %w", dash.UID(), err))
-			continue
-		}
-		dl.Info("dashboard deleted from Grafana")
-	}
-
-	// If any errors occurred, combine them and return
-	if len(errs) > 0 {
-		return errors.Join(errs...)
+		log.FromContext(ctx).Info("dashboard deleted from Grafana")
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	// Cleanup orphaned folders after all dashboards are deleted
@@ -280,12 +220,57 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 	}
 
 	// Finalizer handling needs to come last.
-	err := r.finalizerHelper.EnsureRemoved(ctx, dashboardConfigMap)
-	if err != nil {
+	if err := r.finalizerHelper.EnsureRemoved(ctx, dashboardConfigMap); err != nil {
 		return fmt.Errorf("failed to remove finalizer: %w", err)
 	}
 
 	return nil
+}
+
+// processDashboards applies op to every dashboard parsed from the ConfigMap.
+// Errors are collected per dashboard so that a single failure does not prevent
+// the remaining dashboards from being processed. It returns the organization
+// shared by the dashboards (empty if the ConfigMap holds none) along with the
+// joined errors.
+//
+// Validation and error logging live here because controller-runtime's own error
+// logging is disabled (see Reconcile): this is the only place per-dashboard
+// failures get logged.
+func (r *DashboardReconciler) processDashboards(
+	ctx context.Context,
+	dashboardConfigMap *v1.ConfigMap,
+	op func(ctx context.Context, dash *dashboard.Dashboard) error,
+) (string, error) {
+	logger := log.FromContext(ctx)
+	dashboards := r.dashboardMapper.FromConfigMap(dashboardConfigMap)
+
+	org := ""
+	var errs []error
+	for _, dash := range dashboards {
+		// org is the same for all dashboards in the same configmap.
+		org = dash.Organization()
+
+		// Create a unique logger for the current dashboard.
+		dl := logger.WithValues(
+			"uid", dash.UID(),
+			"organization", dash.Organization(),
+			"folder", dash.FolderPath(),
+		)
+
+		// Defensive validation: ensure dashboards are valid even if webhook was bypassed.
+		if validationErrors := dash.Validate(); len(validationErrors) > 0 {
+			dl.Error(nil, "dashboard validation failed during reconciliation - webhook may have been bypassed", "errors", validationErrors)
+			errs = append(errs, fmt.Errorf("dashboard validation failed for uid %s: %v", dash.UID(), validationErrors))
+			continue
+		}
+
+		if err := op(log.IntoContext(ctx, dl), dash); err != nil {
+			dl.Error(err, "failed to reconcile dashboard")
+			errs = append(errs, fmt.Errorf("uid %s: %w", dash.UID(), err))
+		}
+	}
+
+	return org, errors.Join(errs...)
 }
 
 // cleanupOrphanedFolders resolves the organization, computes which folder UIDs are still

--- a/internal/webhook/v1/dashboard_configmap_webhook.go
+++ b/internal/webhook/v1/dashboard_configmap_webhook.go
@@ -108,7 +108,7 @@ func (v *DashboardConfigMapValidator) validateDashboard(ctx context.Context, con
 	for _, dash := range dashboards {
 		errs := dash.Validate()
 		if len(errs) > 0 {
-			return nil, fmt.Errorf("dashboard validation failed for uid %s: %w", dash.UID(), errors.Join(errs...))
+			return nil, fmt.Errorf("dashboard validation failed for uid=%s in configMap=%s/%s:%w", dash.UID(), configmap.GetNamespace(), configmap.GetName(), errors.Join(errs...))
 		}
 	}
 
@@ -123,7 +123,7 @@ func (v *DashboardConfigMapValidator) validateDashboard(ctx context.Context, con
 	}
 	for _, dash := range dashboards {
 		if _, ok := existingOrgs[dash.Organization()]; !ok {
-			return nil, fmt.Errorf("organization %q referenced by dashboard %q does not exist", dash.Organization(), dash.UID())
+			return nil, fmt.Errorf("organization %q referenced by dashboard uid=%q in configMap=%s/%s does not exist", dash.Organization(), dash.UID(), configmap.GetNamespace(), configmap.GetName())
 		}
 	}
 

--- a/internal/webhook/v1/dashboard_configmap_webhook.go
+++ b/internal/webhook/v1/dashboard_configmap_webhook.go
@@ -108,7 +108,7 @@ func (v *DashboardConfigMapValidator) validateDashboard(ctx context.Context, con
 	for _, dash := range dashboards {
 		errs := dash.Validate()
 		if len(errs) > 0 {
-			return nil, fmt.Errorf("dashboard validation failed for uid=%s in configMap=%s/%s:%w", dash.UID(), configmap.GetNamespace(), configmap.GetName(), errors.Join(errs...))
+			return nil, fmt.Errorf("dashboard validation failed for uid=%s in configMap=%s/%s: %w", dash.UID(), configmap.GetNamespace(), configmap.GetName(), errors.Join(errs...))
 		}
 	}
 


### PR DESCRIPTION
## What

Follow-up cleanup of the dashboard controller and webhook logging, continuing the work from #858.

### Added

- Normalize the `uid`, `organization`, `folder` log keys

<img width="1920" height="70" alt="image" src="https://github.com/user-attachments/assets/dbbf346d-d424-4ac2-9952-cb6c8793a927" />

- Add the source ConfigMap (`configMap=<namespace>/<name>`) in dashboard configure/delete/validation error messages and in the webhook validation errors

### Changed

- Extract common (parse/validate/loop/collect-errors) logic from `reconcileCreate` and `reconcileDelete` into a shared `processDashboards` helper that parses the ConfigMap, runs per-dashboard validation, and applies a caller-supplied `op` (create, delete).

### Removed

- Removed redundant log keys about the configmap

<img width="1920" height="88" alt="image" src="https://github.com/user-attachments/assets/fe86d811-bc29-46c5-95a5-67b8c2fe635c" />

- Removed duplicated error log entries (due to both logging and returning errors) - kept the standard "Reconcile Error" from the controller runtime (we can't hide it anyway).

<img width="1920" height="666" alt="image" src="https://github.com/user-attachments/assets/18fb3e13-dc47-4e75-bcfb-18f0914b7e4b" />

## Notes

No behavioural change to reconciliation outcomes — same validation, same per-dashboard error collection, same orphaned-folder cleanup and finalizer ordering.

### Output

<img width="1920" height="954" alt="image" src="https://github.com/user-attachments/assets/08124975-3d64-4945-93a9-52e02b1525a3" />
