### PR TITLE
feat: Run orphaned dashboard-folder cleanup asynchronously

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve dashboard controller speed
   - Cache Grafana organization lookups
+  - Cache dashboard folder hierarchies lookups
 - Update dashboard controller log entries
   - Simplify per dashboard logging
   - Remove redundant log lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Improve log messages
-  - Normalize per dashboard logging (with uid, organization and folder keys)
+- Improve dashboard controller speed
+  - Cache Grafana organization lookups
+- Update dashboard controller log entries
+  - Simplify per dashboard logging
   - Remove redundant log lines
   - Remove started/finished log entries
   - Add ConfigMap information in errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve dashboard controller speed
   - Cache Grafana organization lookups
   - Cache dashboard folder hierarchy lookups
+  - Run orphaned-folder cleanup asynchronously off the reconcile path
 - Improve log messages
   - Normalize per dashboard logging (with uid, organization and folder keys)
   - Remove redundant log lines

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improve dashboard controller speed
   - Cache Grafana organization lookups
   - Cache dashboard folder hierarchies lookups
-- Update dashboard controller log entries
+- Improve log messages
+  - Normalize per dashboard logging (with uid, organization and folder keys)
   - Simplify per dashboard logging
   - Remove redundant log lines
   - Remove started/finished log entries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cache dashboard folder hierarchies lookups
 - Improve log messages
   - Normalize per dashboard logging (with uid, organization and folder keys)
-  - Simplify per dashboard logging
   - Remove redundant log lines
   - Remove started/finished log entries
   - Add ConfigMap information in errors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Improve dashboard controller speed
   - Cache Grafana organization lookups
-  - Cache dashboard folder hierarchies lookups
+  - Cache dashboard folder hierarchy lookups
 - Improve log messages
   - Normalize per dashboard logging (with uid, organization and folder keys)
   - Remove redundant log lines

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/go-openapi/runtime v0.32.3
 	github.com/goccy/go-yaml v1.19.2
 	github.com/grafana/grafana-openapi-client-go v0.0.0-20260604125106-9550bcd4956c
+	github.com/jellydator/ttlcache/v3 v3.4.0
 	github.com/onsi/ginkgo/v2 v2.31.0
 	github.com/onsi/gomega v1.42.0
 	github.com/prometheus/alertmanager v0.32.1

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/huandu/xstrings v1.5.0 h1:2ag3IFq9ZDANvthTwTiqSSZLjDc+BedvHPAp5tJy2TI=
 github.com/huandu/xstrings v1.5.0/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
+github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -39,7 +39,10 @@ type DashboardReconciler struct {
 	dashboardMapper  *mapper.DashboardMapper
 	grafanaClientGen grafanaclient.GrafanaClientGenerator
 	cfg              config.Config
-	cleaner          *folderCleaner
+
+	// cleaner is responsible for cleaning up orphaned Grafana folders that are no longer referenced by any dashboard configmap.
+	// It runs asynchronously, debounced after the last reconciliation.
+	cleaner *folderCleaner
 }
 
 const DashboardFinalizer = "observability.giantswarm.io/grafanadashboard"
@@ -57,8 +60,7 @@ func SetupDashboardReconciler(mgr manager.Manager, cfg config.Config, grafanaCli
 		cleaner:          newFolderCleaner(mgr.GetClient(), grafanaClientGen, cfg.Grafana.URL, cfg),
 	}
 
-	// The cleaner runs orphaned-folder cleanup asynchronously, debounced after
-	// the last reconciliation. The manager owns its lifecycle.
+	// Add the cleaner to the manager so that it can be started and stopped with the manager.
 	if err := mgr.Add(r.cleaner); err != nil {
 		return fmt.Errorf("failed to add dashboard folder cleaner: %w", err)
 	}

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/giantswarm/observability-operator/internal/predicates"
 	"github.com/giantswarm/observability-operator/pkg/config"
 	"github.com/giantswarm/observability-operator/pkg/domain/dashboard"
-	"github.com/giantswarm/observability-operator/pkg/domain/folder"
 	"github.com/giantswarm/observability-operator/pkg/grafana"
 	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
 )
@@ -40,6 +39,7 @@ type DashboardReconciler struct {
 	dashboardMapper  *mapper.DashboardMapper
 	grafanaClientGen grafanaclient.GrafanaClientGenerator
 	cfg              config.Config
+	cleaner          *folderCleaner
 }
 
 const DashboardFinalizer = "observability.giantswarm.io/grafanadashboard"
@@ -54,6 +54,13 @@ func SetupDashboardReconciler(mgr manager.Manager, cfg config.Config, grafanaCli
 		dashboardMapper:  mapper.New(),
 		grafanaClientGen: grafanaClientGen,
 		cfg:              cfg,
+		cleaner:          newFolderCleaner(mgr.GetClient(), grafanaClientGen, cfg.Grafana.URL, cfg),
+	}
+
+	// The cleaner runs orphaned-folder cleanup asynchronously, debounced after
+	// the last reconciliation. The manager owns its lifecycle.
+	if err := mgr.Add(r.cleaner); err != nil {
+		return fmt.Errorf("failed to add dashboard folder cleaner: %w", err)
 	}
 
 	return r.SetupWithManager(mgr)
@@ -180,12 +187,8 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 		return err
 	}
 
-	// Cleanup orphaned folders after all dashboards are processed
-	if org != "" {
-		if err := r.cleanupOrphanedFolders(ctx, grafanaService, org); err != nil {
-			return fmt.Errorf("failed to cleanup orphaned folders: %w", err)
-		}
-	}
+	// Request asynchronous, debounced cleanup of orphaned folders for this org.
+	r.cleaner.Trigger(org)
 
 	return nil
 }
@@ -208,12 +211,8 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 		return err
 	}
 
-	// Cleanup orphaned folders after all dashboards are deleted
-	if org != "" {
-		if err := r.cleanupOrphanedFolders(ctx, grafanaService, org); err != nil {
-			return fmt.Errorf("failed to cleanup orphaned folders: %w", err)
-		}
-	}
+	// Request asynchronous, debounced cleanup of orphaned folders for this org.
+	r.cleaner.Trigger(org)
 
 	// Finalizer handling needs to come last.
 	if err := r.finalizerHelper.EnsureRemoved(ctx, dashboardConfigMap); err != nil {
@@ -261,50 +260,4 @@ func (r *DashboardReconciler) processDashboards(
 	}
 
 	return org, errors.Join(errs...)
-}
-
-// cleanupOrphanedFolders resolves the organization, computes which folder UIDs are still
-// needed by dashboard ConfigMaps, and delegates deletion of orphans to the Grafana service.
-func (r *DashboardReconciler) cleanupOrphanedFolders(ctx context.Context, grafanaService *grafana.Service, orgName string) error {
-	org, err := grafanaService.FindOrgByName(orgName)
-	if err != nil {
-		return fmt.Errorf("failed to find organization %q: %w", orgName, err)
-	}
-
-	requiredUIDs, err := r.collectRequiredFolderUIDs(ctx, orgName)
-	if err != nil {
-		return fmt.Errorf("failed to collect required folder UIDs: %w", err)
-	}
-
-	return grafanaService.CleanupOrphanedFoldersForOrg(ctx, org, requiredUIDs)
-}
-
-// collectRequiredFolderUIDs lists all dashboard ConfigMaps for the given organization and computes the set of folder UIDs they reference.
-func (r *DashboardReconciler) collectRequiredFolderUIDs(ctx context.Context, orgName string) (map[string]struct{}, error) {
-	var configMaps v1.ConfigMapList
-	err := r.List(ctx, &configMaps, client.MatchingLabels{
-		labels.DashboardSelectorLabelName: labels.DashboardSelectorLabelValue,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list dashboard configmaps: %w", err)
-	}
-
-	requiredUIDs := make(map[string]struct{})
-	for i := range configMaps.Items {
-		dashboards := r.dashboardMapper.FromConfigMap(&configMaps.Items[i])
-		for _, dash := range dashboards {
-			if dash.Organization() != orgName {
-				continue
-			}
-			if dash.FolderPath() == "" {
-				continue
-			}
-			segments := folder.ParsePath(dash.FolderPath())
-			for _, seg := range segments {
-				requiredUIDs[seg.UID()] = struct{}{}
-			}
-		}
-	}
-
-	return requiredUIDs, nil
 }

--- a/internal/controller/dashboard_controller_test.go
+++ b/internal/controller/dashboard_controller_test.go
@@ -197,12 +197,13 @@ var _ = Describe("Dashboard Controller", func() {
 						},
 					}, nil)
 
-				// Mock the Folders service for cleanup
+				// Folder cleanup now runs asynchronously in the debounced folderCleaner,
+				// not during Reconcile, so these calls are optional in these tests.
 				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
+				mockGrafanaClient.On("Folders").Return(mockFoldersClient).Maybe()
 				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
 					Payload: []*models.FolderSearchHit{},
-				}, nil)
+				}, nil).Maybe()
 			})
 
 			AfterEach(func() {
@@ -340,12 +341,13 @@ var _ = Describe("Dashboard Controller", func() {
 					return false
 				})).Return(dashboardResponse, nil)
 
-				// Mock the Folders service for cleanup
+				// Folder cleanup now runs asynchronously in the debounced folderCleaner,
+				// not during Reconcile, so these calls are optional in these tests.
 				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
+				mockGrafanaClient.On("Folders").Return(mockFoldersClient).Maybe()
 				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
 					Payload: []*models.FolderSearchHit{},
-				}, nil)
+				}, nil).Maybe()
 
 				By("Creating a dashboard ConfigMap")
 				Expect(k8sClient.Create(ctx, dashboardConfigMap)).To(Succeed())
@@ -565,12 +567,13 @@ var _ = Describe("Dashboard Controller", func() {
 				}
 				mockDashboardsClient.On("DeleteDashboardByUID", "test-dashboard-uid").Return(deleteResponse, nil)
 
-				// Mock the Folders service for cleanup
+				// Folder cleanup now runs asynchronously in the debounced folderCleaner,
+				// not during Reconcile, so these calls are optional in these tests.
 				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
+				mockGrafanaClient.On("Folders").Return(mockFoldersClient).Maybe()
 				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
 					Payload: []*models.FolderSearchHit{},
-				}, nil)
+				}, nil).Maybe()
 
 				By("Marking the dashboard ConfigMap for deletion")
 				createdConfigMap := &v1.ConfigMap{}
@@ -682,12 +685,13 @@ var _ = Describe("Dashboard Controller", func() {
 				}
 				mockDashboardsClient.On("PostDashboard", mock.Anything).Return(dashboardResponse, nil)
 
-				// Mock the Folders service for cleanup
+				// Folder cleanup now runs asynchronously in the debounced folderCleaner,
+				// not during Reconcile, so these calls are optional in these tests.
 				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
+				mockGrafanaClient.On("Folders").Return(mockFoldersClient).Maybe()
 				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
 					Payload: []*models.FolderSearchHit{},
-				}, nil)
+				}, nil).Maybe()
 
 				// Test ConfigMap with organization in labels instead of annotations
 				// Note: Using a valid Kubernetes label value (no spaces, alphanumeric + dashes/dots/underscores)
@@ -843,12 +847,13 @@ var _ = Describe("Dashboard Controller", func() {
 				mockDashboardsClient := &mocks.MockDashboardsClient{}
 				mockGrafanaClient.On("Dashboards").Return(mockDashboardsClient)
 
-				// Mock the Folders service for cleanup
+				// Folder cleanup now runs asynchronously in the debounced folderCleaner,
+				// not during Reconcile, so these calls are optional in these tests.
 				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
+				mockGrafanaClient.On("Folders").Return(mockFoldersClient).Maybe()
 				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
 					Payload: []*models.FolderSearchHit{},
-				}, nil)
+				}, nil).Maybe()
 
 				configMapWithID := &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
@@ -985,12 +990,13 @@ var _ = Describe("Dashboard Controller", func() {
 				mockDashboardsClient := &mocks.MockDashboardsClient{}
 				mockGrafanaClient.On("Dashboards").Return(mockDashboardsClient)
 
-				// Mock the Folders service for cleanup
+				// Folder cleanup now runs asynchronously in the debounced folderCleaner,
+				// not during Reconcile, so these calls are optional in these tests.
 				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
+				mockGrafanaClient.On("Folders").Return(mockFoldersClient).Maybe()
 				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
 					Payload: []*models.FolderSearchHit{},
-				}, nil)
+				}, nil).Maybe()
 
 				// Mock the organization lookup to succeed
 				orgResponse := &orgs.GetOrgByNameOK{

--- a/internal/controller/dashboard_folder_cleaner.go
+++ b/internal/controller/dashboard_folder_cleaner.go
@@ -1,0 +1,169 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/giantswarm/observability-operator/internal/labels"
+	"github.com/giantswarm/observability-operator/internal/mapper"
+	"github.com/giantswarm/observability-operator/pkg/config"
+	"github.com/giantswarm/observability-operator/pkg/domain/folder"
+	"github.com/giantswarm/observability-operator/pkg/grafana"
+	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
+)
+
+// folderCleanupDebounceInterval is how long the cleaner waits for a burst of
+// reconciliations to settle before running orphaned-folder cleanup. Every
+// Trigger resets this window, so cleanup runs once after the last reconcile.
+const folderCleanupDebounceInterval = 10 * time.Second
+
+// folderCleaner debounces orphaned Grafana folder cleanup.
+//
+// Dashboard reconciliations can arrive in bursts (e.g. a Grafana pod restart
+// re-enqueues every dashboard ConfigMap at once). Running the cleanup — which
+// lists all folders and dashboards for an organization — after each reconcile
+// would be wasteful, so reconciliations only call Trigger to request one. The
+// actual cleanup runs once the burst settles: each Trigger resets a debounce
+// timer, and cleanup runs only after no Trigger has arrived for the debounce
+// interval. The cleaner stays idle until triggered — it never runs on its own.
+type folderCleaner struct {
+	client           client.Client
+	grafanaClientGen grafanaclient.GrafanaClientGenerator
+	grafanaURL       *url.URL
+	cfg              config.Config
+	dashboardMapper  *mapper.DashboardMapper
+
+	interval time.Duration
+	requests chan string
+}
+
+func newFolderCleaner(c client.Client, grafanaClientGen grafanaclient.GrafanaClientGenerator, grafanaURL *url.URL, cfg config.Config) *folderCleaner {
+	return &folderCleaner{
+		client:           c,
+		grafanaClientGen: grafanaClientGen,
+		grafanaURL:       grafanaURL,
+		cfg:              cfg,
+		dashboardMapper:  mapper.New(),
+		interval:         folderCleanupDebounceInterval,
+		requests:         make(chan string, 1024),
+	}
+}
+
+// Trigger requests an orphaned-folder cleanup for the given organization. It is
+// safe to call from any reconcile goroutine and never blocks: it only schedules
+// work — the cleanup itself runs asynchronously in Start.
+func (c *folderCleaner) Trigger(orgName string) {
+	if c == nil || orgName == "" {
+		return
+	}
+	select {
+	case c.requests <- orgName:
+	default:
+		// The request buffer is full, meaning a cleanup is already queued for
+		// the current burst. Dropping is safe: the queued cleanup recomputes
+		// the required folders from live cluster state anyway.
+	}
+}
+
+// Start runs the debounce loop until ctx is cancelled. It implements
+// manager.Runnable so the controller manager owns its lifecycle.
+func (c *folderCleaner) Start(ctx context.Context) error {
+	logger := log.FromContext(ctx).WithName("dashboard-folder-cleaner")
+
+	// The timer is created stopped so the cleaner never runs until the first
+	// Trigger arms it.
+	timer := time.NewTimer(c.interval)
+	if !timer.Stop() {
+		<-timer.C
+	}
+
+	pending := make(map[string]struct{})
+
+	for {
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		case org := <-c.requests:
+			pending[org] = struct{}{}
+			// Reset the debounce window: cleanup only fires once reconciles stop.
+			timer.Reset(c.interval)
+		case <-timer.C:
+			orgs := pending
+			pending = make(map[string]struct{})
+			c.runCleanup(ctx, logger, orgs)
+		}
+	}
+}
+
+func (c *folderCleaner) runCleanup(ctx context.Context, logger logr.Logger, orgs map[string]struct{}) {
+	if len(orgs) == 0 {
+		return
+	}
+
+	grafanaAPI, err := c.grafanaClientGen.GenerateGrafanaClient(ctx, c.client, c.grafanaURL)
+	if err != nil {
+		logger.Error(err, "failed to generate Grafana client for folder cleanup")
+		return
+	}
+	grafanaService := grafana.NewService(grafanaAPI, c.cfg)
+
+	for orgName := range orgs {
+		if err := c.cleanupOrphanedFolders(ctx, grafanaService, orgName); err != nil {
+			logger.Error(err, "failed to cleanup orphaned folders", "organization", orgName)
+		}
+	}
+}
+
+// cleanupOrphanedFolders resolves the organization, computes which folder UIDs are still
+// needed by dashboard ConfigMaps, and delegates deletion of orphans to the Grafana service.
+func (c *folderCleaner) cleanupOrphanedFolders(ctx context.Context, grafanaService *grafana.Service, orgName string) error {
+	org, err := grafanaService.FindOrgByName(orgName)
+	if err != nil {
+		return fmt.Errorf("failed to find organization %q: %w", orgName, err)
+	}
+
+	requiredUIDs, err := c.collectRequiredFolderUIDs(ctx, orgName)
+	if err != nil {
+		return fmt.Errorf("failed to collect required folder UIDs: %w", err)
+	}
+
+	return grafanaService.CleanupOrphanedFoldersForOrg(ctx, org, requiredUIDs)
+}
+
+// collectRequiredFolderUIDs lists all dashboard ConfigMaps for the given organization and computes the set of folder UIDs they reference.
+func (c *folderCleaner) collectRequiredFolderUIDs(ctx context.Context, orgName string) (map[string]struct{}, error) {
+	var configMaps v1.ConfigMapList
+	err := c.client.List(ctx, &configMaps, client.MatchingLabels{
+		labels.DashboardSelectorLabelName: labels.DashboardSelectorLabelValue,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dashboard configmaps: %w", err)
+	}
+
+	requiredUIDs := make(map[string]struct{})
+	for i := range configMaps.Items {
+		dashboards := c.dashboardMapper.FromConfigMap(&configMaps.Items[i])
+		for _, dash := range dashboards {
+			if dash.Organization() != orgName {
+				continue
+			}
+			if dash.FolderPath() == "" {
+				continue
+			}
+			segments := folder.ParsePath(dash.FolderPath())
+			for _, seg := range segments {
+				requiredUIDs[seg.UID()] = struct{}{}
+			}
+		}
+	}
+
+	return requiredUIDs, nil
+}

--- a/internal/controller/dashboard_folder_cleaner.go
+++ b/internal/controller/dashboard_folder_cleaner.go
@@ -104,33 +104,45 @@ func (c *folderCleaner) Start(ctx context.Context) error {
 			// Timer fired, meaning no new requests have arrived for the debounce interval. Run the cleanup for all pending organizations.
 			orgs := pending
 			pending = make(map[string]struct{})
-			c.runCleanup(ctx, logger, orgs)
+			// Carry forward any orgs whose cleanup failed so a transient error
+			// (e.g. Grafana briefly unavailable) is retried after the next
+			// debounce window instead of being silently dropped.
+			pending = c.runCleanup(ctx, logger, orgs)
+			if len(pending) > 0 {
+				timer.Reset(c.interval)
+			}
 		}
 	}
 }
 
 // runCleanup performs the actual cleanup of orphaned folders for the given organizations.
 // It generates a Grafana client and delegates the cleanup to the Grafana service.
-func (c *folderCleaner) runCleanup(ctx context.Context, logger logr.Logger, orgs map[string]struct{}) {
+// It returns the set of organizations whose cleanup failed so the caller can retry
+// them on a later debounce window instead of dropping them.
+func (c *folderCleaner) runCleanup(ctx context.Context, logger logr.Logger, orgs map[string]struct{}) map[string]struct{} {
 	if len(orgs) == 0 {
-		return
+		return nil
 	}
 
 	// Create a Grafana API client for the cleanup operation.
 	grafanaAPI, err := c.grafanaClientGen.GenerateGrafanaClient(ctx, c.client, c.grafanaURL)
 	if err != nil {
+		// No org could be processed without a client, so retry all of them.
 		logger.Error(err, "failed to generate Grafana client for folder cleanup")
-		return
+		return orgs
 	}
 
 	grafanaService := grafana.NewService(grafanaAPI, c.cfg)
 
 	// Perform cleanup for each given organization.
+	failed := make(map[string]struct{})
 	for orgName := range orgs {
 		if err := c.cleanupOrphanedFolders(ctx, grafanaService, orgName); err != nil {
 			logger.Error(err, "failed to cleanup orphaned folders", "organization", orgName)
+			failed[orgName] = struct{}{}
 		}
 	}
+	return failed
 }
 
 // cleanupOrphanedFolders resolves the organization, computes which folder UIDs are still

--- a/internal/controller/dashboard_folder_cleaner.go
+++ b/internal/controller/dashboard_folder_cleaner.go
@@ -26,13 +26,13 @@ const folderCleanupDebounceInterval = 10 * time.Second
 
 // folderCleaner debounces orphaned Grafana folder cleanup.
 //
-// Dashboard reconciliations can arrive in bursts (e.g. a Grafana pod restart
-// re-enqueues every dashboard ConfigMap at once). Running the cleanup — which
-// lists all folders and dashboards for an organization — after each reconcile
-// would be wasteful, so reconciliations only call Trigger to request one. The
-// actual cleanup runs once the burst settles: each Trigger resets a debounce
-// timer, and cleanup runs only after no Trigger has arrived for the debounce
-// interval. The cleaner stays idle until triggered — it never runs on its own.
+// Running the cleanup is expensive at is needs to lists all folders and
+// dashboards for an organization. Since dashboard reconciliations can arrive
+// in bursts (e.g. a Grafana pod restart re-enqueues every dashboard ConfigMap
+// at once), this cleaner runs the actual cleanup once the burst settles: each
+// Trigger resets a debounce timer, and cleanup runs only after no Trigger has
+// arrived for the debounce interval. The cleaner stays idle until triggered —
+// it never runs on its own.
 type folderCleaner struct {
 	client           client.Client
 	grafanaClientGen grafanaclient.GrafanaClientGenerator
@@ -60,9 +60,11 @@ func newFolderCleaner(c client.Client, grafanaClientGen grafanaclient.GrafanaCli
 // safe to call from any reconcile goroutine and never blocks: it only schedules
 // work — the cleanup itself runs asynchronously in Start.
 func (c *folderCleaner) Trigger(orgName string) {
+	// Do not enqueue a cleanup if the cleaner is not initialized or the organization name is empty.
 	if c == nil || orgName == "" {
 		return
 	}
+
 	select {
 	case c.requests <- orgName:
 	default:
@@ -81,6 +83,7 @@ func (c *folderCleaner) Start(ctx context.Context) error {
 	// Trigger arms it.
 	timer := time.NewTimer(c.interval)
 	if !timer.Stop() {
+		// If we can't stop the timer, it means it has already fired. Drain the channel to ensure we don't receive a spurious event later.
 		<-timer.C
 	}
 
@@ -89,13 +92,16 @@ func (c *folderCleaner) Start(ctx context.Context) error {
 	for {
 		select {
 		case <-ctx.Done():
+			// Context cancellation was triggered, stop the timer and exit the loop.
 			timer.Stop()
 			return nil
 		case org := <-c.requests:
+			// A cleanup request was received for an organization.
+			// Add it to the pending set and reset the debounce timer, so cleanup will run after the interval if no new requests arrive.
 			pending[org] = struct{}{}
-			// Reset the debounce window: cleanup only fires once reconciles stop.
 			timer.Reset(c.interval)
 		case <-timer.C:
+			// Timer fired, meaning no new requests have arrived for the debounce interval. Run the cleanup for all pending organizations.
 			orgs := pending
 			pending = make(map[string]struct{})
 			c.runCleanup(ctx, logger, orgs)
@@ -103,18 +109,23 @@ func (c *folderCleaner) Start(ctx context.Context) error {
 	}
 }
 
+// runCleanup performs the actual cleanup of orphaned folders for the given organizations.
+// It generates a Grafana client and delegates the cleanup to the Grafana service.
 func (c *folderCleaner) runCleanup(ctx context.Context, logger logr.Logger, orgs map[string]struct{}) {
 	if len(orgs) == 0 {
 		return
 	}
 
+	// Create a Grafana API client for the cleanup operation.
 	grafanaAPI, err := c.grafanaClientGen.GenerateGrafanaClient(ctx, c.client, c.grafanaURL)
 	if err != nil {
 		logger.Error(err, "failed to generate Grafana client for folder cleanup")
 		return
 	}
+
 	grafanaService := grafana.NewService(grafanaAPI, c.cfg)
 
+	// Perform cleanup for each given organization.
 	for orgName := range orgs {
 		if err := c.cleanupOrphanedFolders(ctx, grafanaService, orgName); err != nil {
 			logger.Error(err, "failed to cleanup orphaned folders", "organization", orgName)

--- a/internal/controller/dashboard_folder_cleaner.go
+++ b/internal/controller/dashboard_folder_cleaner.go
@@ -3,11 +3,13 @@ package controller
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/url"
 	"time"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -23,6 +25,25 @@ import (
 // reconciliations to settle before running orphaned-folder cleanup. Every
 // Trigger resets this window, so cleanup runs once after the last reconcile.
 const folderCleanupDebounceInterval = 10 * time.Second
+
+// folderCleanupMaxRetryInterval caps the exponential backoff applied between
+// retries when cleanup keeps failing (e.g. Grafana unavailable).
+const folderCleanupMaxRetryInterval = 5 * time.Minute
+
+// newFolderCleanupBackoff returns the retry schedule used when a cleanup fails:
+// jittered exponential growth from interval up to folderCleanupMaxRetryInterval.
+// Steps is effectively unbounded so the schedule keeps stepping until it caps
+// out rather than exhausting. A fresh value is created on each new burst and
+// after a successful run, which resets the backoff to interval.
+func newFolderCleanupBackoff(interval time.Duration) wait.Backoff {
+	return wait.Backoff{
+		Duration: interval,
+		Factor:   2,
+		Jitter:   0.5,
+		Steps:    math.MaxInt32,
+		Cap:      folderCleanupMaxRetryInterval,
+	}
+}
 
 // folderCleaner debounces orphaned Grafana folder cleanup.
 //
@@ -88,6 +109,7 @@ func (c *folderCleaner) Start(ctx context.Context) error {
 	}
 
 	pending := make(map[string]struct{})
+	retry := newFolderCleanupBackoff(c.interval)
 
 	for {
 		select {
@@ -100,16 +122,21 @@ func (c *folderCleaner) Start(ctx context.Context) error {
 			// Add it to the pending set and reset the debounce timer, so cleanup will run after the interval if no new requests arrive.
 			pending[org] = struct{}{}
 			timer.Reset(c.interval)
+
+			// Reset the retry backoff to the initial interval, so if the next cleanup fails, it will start from the base interval again.
+			retry = newFolderCleanupBackoff(c.interval)
 		case <-timer.C:
 			// Timer fired, meaning no new requests have arrived for the debounce interval. Run the cleanup for all pending organizations.
 			orgs := pending
-			pending = make(map[string]struct{})
 			// Carry forward any orgs whose cleanup failed so a transient error
-			// (e.g. Grafana briefly unavailable) is retried after the next
-			// debounce window instead of being silently dropped.
+			// (e.g. Grafana briefly unavailable) is retried instead of being
+			// silently dropped. runCleanup returns a fresh map (or nil on full
+			// success), so reassigning pending here resets it for the next window.
 			pending = c.runCleanup(ctx, logger, orgs)
 			if len(pending) > 0 {
-				timer.Reset(c.interval)
+				// Cleanup failed for some orgs: back off exponentially before
+				// retrying so a sustained Grafana outage is not hammered.
+				timer.Reset(retry.Step())
 			}
 		}
 	}

--- a/pkg/grafana/dashboard.go
+++ b/pkg/grafana/dashboard.go
@@ -23,7 +23,7 @@ func (s *Service) ConfigureDashboard(ctx context.Context, dashboard *dashboard.D
 
 	err = s.withinOrganization(ctx, org, func(ctx context.Context, client grafanaclient.GrafanaClient) error {
 		// Ensure folder hierarchy exists and get the leaf folder UID
-		folderUID, err := s.ensureFolderHierarchy(ctx, client, dashboard.FolderPath())
+		folderUID, err := s.ensureFolderHierarchy(ctx, client, org.ID(), dashboard.FolderPath())
 		if err != nil {
 			return fmt.Errorf("failed to ensure folder hierarchy: %w", err)
 		}

--- a/pkg/grafana/folder.go
+++ b/pkg/grafana/folder.go
@@ -18,14 +18,16 @@ import (
 // ensureFolderHierarchy ensures that the full folder hierarchy exists for the given path.
 // Returns the leaf folder UID, or empty string if path is empty (General folder).
 // The provided client must already be scoped to the target organization.
-func (s *Service) ensureFolderHierarchy(ctx context.Context, client grafanaclient.GrafanaClient, path string) (string, error) {
+func (s *Service) ensureFolderHierarchy(ctx context.Context, client grafanaclient.GrafanaClient, orgID int64, path string) (string, error) {
 	if path == "" {
 		return "", nil
 	}
 
+	cacheKey := folderCacheKey{orgID: orgID, path: path}
+
 	// Return cached folder UID if the folder hierarchy for this path has already been
 	// processed, skipping the per-segment Grafana API calls needed to walk it again.
-	cachedUID := s.foldersCache.Get(path)
+	cachedUID := s.foldersCache.Get(cacheKey)
 	if cachedUID != nil {
 		return cachedUID.Value(), nil
 	}
@@ -73,7 +75,7 @@ func (s *Service) ensureFolderHierarchy(ctx context.Context, client grafanaclien
 	}
 
 	// Cache the folder UID for this path for future lookups.
-	s.foldersCache.Set(path, leafUID, ttlcache.DefaultTTL)
+	s.foldersCache.Set(cacheKey, leafUID, ttlcache.DefaultTTL)
 
 	return leafUID, nil
 }

--- a/pkg/grafana/folder.go
+++ b/pkg/grafana/folder.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	ttlcache "github.com/jellydator/ttlcache/v3"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/giantswarm/observability-operator/pkg/domain/folder"
@@ -20,6 +21,13 @@ import (
 func (s *Service) ensureFolderHierarchy(ctx context.Context, client grafanaclient.GrafanaClient, path string) (string, error) {
 	if path == "" {
 		return "", nil
+	}
+
+	// Return cached folder UID if the folder hierarchy for this path has already been
+	// processed, skipping the per-segment Grafana API calls needed to walk it again.
+	cachedUID := s.foldersCache.Get(path)
+	if cachedUID != nil {
+		return cachedUID.Value(), nil
 	}
 
 	logger := log.FromContext(ctx)
@@ -63,6 +71,9 @@ func (s *Service) ensureFolderHierarchy(ctx context.Context, client grafanaclien
 			}
 		}
 	}
+
+	// Cache the folder UID for this path for future lookups.
+	s.foldersCache.Set(path, leafUID, ttlcache.DefaultTTL)
 
 	return leafUID, nil
 }

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -6,10 +6,12 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	goruntime "github.com/go-openapi/runtime"
 	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	ttlcache "github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/mock"
 
 	"github.com/giantswarm/observability-operator/pkg/domain/folder"
@@ -18,8 +20,12 @@ import (
 )
 
 func newTestService(mockClient *mocks.MockGrafanaClient) *Service {
+	organizationCache := ttlcache.New(
+		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
+	)
 	return &Service{
-		grafanaClient: mockClient,
+		grafanaClient:     mockClient,
+		organizationCache: organizationCache,
 	}
 }
 

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -25,10 +25,12 @@ const testFolderCacheOrgID int64 = 1
 
 func newTestService(mockClient *mocks.MockGrafanaClient) *Service {
 	organizationCache := ttlcache.New(
-		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
+		ttlcache.WithTTL[string, *organization.Organization](1*time.Minute),
+		ttlcache.WithDisableTouchOnHit[string, *organization.Organization](),
 	)
 	foldersCache := ttlcache.New(
-		ttlcache.WithTTL[folderCacheKey, string](1 * time.Minute),
+		ttlcache.WithTTL[folderCacheKey, string](1*time.Minute),
+		ttlcache.WithDisableTouchOnHit[folderCacheKey, string](),
 	)
 
 	return &Service{

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -23,9 +23,14 @@ func newTestService(mockClient *mocks.MockGrafanaClient) *Service {
 	organizationCache := ttlcache.New(
 		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
 	)
+	foldersCache := ttlcache.New(
+		ttlcache.WithTTL[string, string](1 * time.Minute),
+	)
+
 	return &Service{
 		grafanaClient:     mockClient,
 		organizationCache: organizationCache,
+		foldersCache:      foldersCache,
 	}
 }
 

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -19,12 +19,16 @@ import (
 	"github.com/giantswarm/observability-operator/pkg/grafana/client/mocks"
 )
 
+// testFolderCacheOrgID is an arbitrary organization ID used to scope folder cache
+// entries in tests.
+const testFolderCacheOrgID int64 = 1
+
 func newTestService(mockClient *mocks.MockGrafanaClient) *Service {
 	organizationCache := ttlcache.New(
 		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
 	)
 	foldersCache := ttlcache.New(
-		ttlcache.WithTTL[string, string](1 * time.Minute),
+		ttlcache.WithTTL[folderCacheKey, string](1 * time.Minute),
 	)
 
 	return &Service{
@@ -38,7 +42,7 @@ func TestEnsureFolderHierarchy_EmptyPath(t *testing.T) {
 	mockClient := &mocks.MockGrafanaClient{}
 	svc := newTestService(mockClient)
 
-	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "")
+	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -62,7 +66,7 @@ func TestEnsureFolderHierarchy_SingleFolder_AlreadyExists(t *testing.T) {
 	}, nil)
 
 	svc := newTestService(mockClient)
-	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "team-a")
+	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "team-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -95,7 +99,7 @@ func TestEnsureFolderHierarchy_SingleFolder_DoesNotExist(t *testing.T) {
 	}, nil)
 
 	svc := newTestService(mockClient)
-	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "team-a")
+	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "team-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -133,7 +137,7 @@ func TestEnsureFolderHierarchy_NestedPath(t *testing.T) {
 	}, nil)
 
 	svc := newTestService(mockClient)
-	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "team-a/networking")
+	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "team-a/networking")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -164,7 +168,7 @@ func TestEnsureFolderHierarchy_Rename(t *testing.T) {
 	}, nil)
 
 	svc := newTestService(mockClient)
-	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "team-a")
+	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "team-a")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -187,7 +191,7 @@ func TestEnsureFolderHierarchy_CreateFolderError(t *testing.T) {
 	mockFolders.On("CreateFolder", mock.Anything).Return(nil, errors.New("grafana unavailable"))
 
 	svc := newTestService(mockClient)
-	_, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "team-a")
+	_, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "team-a")
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -222,7 +226,7 @@ func TestEnsureFolderHierarchy_ThreeLevel(t *testing.T) {
 	})).Return(&folders.CreateFolderOK{Payload: &models.Folder{UID: uid3}}, nil)
 
 	svc := newTestService(mockClient)
-	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "a/b/c")
+	uid, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "a/b/c")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -245,7 +249,7 @@ func TestEnsureFolderHierarchy_GetFolderNon404Error(t *testing.T) {
 		goruntime.NewAPIError("internal server error", nil, http.StatusInternalServerError))
 
 	svc := newTestService(mockClient)
-	_, err := svc.ensureFolderHierarchy(context.Background(), mockClient, "team-a")
+	_, err := svc.ensureFolderHierarchy(context.Background(), mockClient, testFolderCacheOrgID, "team-a")
 	if err == nil {
 		t.Fatal("expected error for 500 response, got nil")
 	}

--- a/pkg/grafana/grafana.go
+++ b/pkg/grafana/grafana.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/go-openapi/runtime"
 	"github.com/grafana/grafana-openapi-client-go/models"
+	ttlcache "github.com/jellydator/ttlcache/v3"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/giantswarm/observability-operator/pkg/domain/organization"
@@ -121,6 +122,13 @@ func isNotFound(err error) bool {
 // It returns organization.ErrOrganizationNotFound (wrapped) when Grafana returns 404,
 // letting callers distinguish a missing organization from other API failures.
 func (s *Service) FindOrgByName(name string) (*organization.Organization, error) {
+	// Return cachedOrganization organization when possible to skip a redundant Grafana API round-trip
+	// for an organization we already resolved recently.
+	cachedOrganization := s.organizationCache.Get(name)
+	if cachedOrganization != nil {
+		return cachedOrganization.Value(), nil
+	}
+
 	org, err := s.grafanaClient.Orgs().GetOrgByName(name)
 	if err != nil {
 		if isNotFound(err) {
@@ -129,7 +137,12 @@ func (s *Service) FindOrgByName(name string) (*organization.Organization, error)
 		return nil, fmt.Errorf("failed to get organization by name: %w", err)
 	}
 
-	return organization.NewFromGrafana(org.Payload.ID, org.Payload.Name), nil
+	result := organization.NewFromGrafana(org.Payload.ID, org.Payload.Name)
+
+	// Cache the organization for future lookups.
+	s.organizationCache.Set(name, result, ttlcache.DefaultTTL)
+
+	return result, nil
 }
 
 // findOrgByID is a wrapper function used to find a Grafana organization by its id

--- a/pkg/grafana/service.go
+++ b/pkg/grafana/service.go
@@ -30,14 +30,12 @@ type Service struct {
 func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *Service {
 	// Initializing organization cache with a TTL of 1 minute.
 	organizationCache := ttlcache.New(
-		// TODO: adjust cache TTL when sharing the grafana service at the controller level.
-		ttlcache.WithTTL[string, *organization.Organization](10 * time.Second),
+		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
 	)
 
 	// Initializing folder path cache with a TTL of 1 minute.
 	foldersCache := ttlcache.New(
-		// TODO: adjust cache TTL when sharing the grafana service at the controller level.
-		ttlcache.WithTTL[string, string](10 * time.Second),
+		ttlcache.WithTTL[string, string](1 * time.Minute),
 	)
 
 	return &Service{

--- a/pkg/grafana/service.go
+++ b/pkg/grafana/service.go
@@ -30,12 +30,14 @@ type Service struct {
 func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *Service {
 	// Initializing organization cache with a TTL of 1 minute.
 	organizationCache := ttlcache.New(
-		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
+		// TODO: adjust cache TTL when sharing the grafana service at the controller level.
+		ttlcache.WithTTL[string, *organization.Organization](10 * time.Second),
 	)
 
 	// Initializing folder path cache with a TTL of 1 minute.
 	foldersCache := ttlcache.New(
-		ttlcache.WithTTL[string, string](1 * time.Minute),
+		// TODO: adjust cache TTL when sharing the grafana service at the controller level.
+		ttlcache.WithTTL[string, string](10 * time.Second),
 	)
 
 	return &Service{

--- a/pkg/grafana/service.go
+++ b/pkg/grafana/service.go
@@ -37,13 +37,17 @@ type folderCacheKey struct {
 
 func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *Service {
 	// Initializing organization cache with a TTL of 1 minute.
+	// DisableTouchOnHit keeps the TTL an absolute expiry so reads do not extend an
+	// entry's lifetime, which would otherwise let a hot entry outlive the freshness window.
 	organizationCache := ttlcache.New(
-		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
+		ttlcache.WithTTL[string, *organization.Organization](1*time.Minute),
+		ttlcache.WithDisableTouchOnHit[string, *organization.Organization](),
 	)
 
 	// Initializing folder path cache with a TTL of 1 minute.
 	foldersCache := ttlcache.New(
-		ttlcache.WithTTL[folderCacheKey, string](1 * time.Minute),
+		ttlcache.WithTTL[folderCacheKey, string](1*time.Minute),
+		ttlcache.WithDisableTouchOnHit[folderCacheKey, string](),
 	)
 
 	return &Service{

--- a/pkg/grafana/service.go
+++ b/pkg/grafana/service.go
@@ -1,18 +1,34 @@
 package grafana
 
 import (
+	"time"
+
 	"github.com/giantswarm/observability-operator/pkg/config"
+	"github.com/giantswarm/observability-operator/pkg/domain/organization"
 	grafanaClient "github.com/giantswarm/observability-operator/pkg/grafana/client"
+
+	ttlcache "github.com/jellydator/ttlcache/v3"
 )
 
 type Service struct {
 	grafanaClient grafanaClient.GrafanaClient
 	cfg           config.Config
+
+	// organizationCache memoizes organization lookups by name to avoid repeating the
+	// same "get org by name" Grafana API call. The short TTL keeps
+	// it fresh enough to pick up organizations created or renamed out-of-band.
+	organizationCache *ttlcache.Cache[string, *organization.Organization]
 }
 
 func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *Service {
+	// Initializing organization cache with a TTL of 1 minute.
+	organizationCache := ttlcache.New(
+		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
+	)
+
 	return &Service{
-		grafanaClient: grafanaClient,
-		cfg:           cfg,
+		grafanaClient:     grafanaClient,
+		cfg:               cfg,
+		organizationCache: organizationCache,
 	}
 }

--- a/pkg/grafana/service.go
+++ b/pkg/grafana/service.go
@@ -24,7 +24,15 @@ type Service struct {
 	// caching the resolved UID avoids re-walking unchanged hierarchies.
 	// The short TTL bounds how long a folder deleted out-of-band stays
 	// "resolved" in the cache.
-	foldersCache *ttlcache.Cache[string, string]
+	// Keyed by organization ID as well as path: folders live per organization, so the
+	// same path must not resolve (or skip creation) across different organizations.
+	foldersCache *ttlcache.Cache[folderCacheKey, string]
+}
+
+// folderCacheKey scopes a cached folder UID to the organization it was resolved in.
+type folderCacheKey struct {
+	orgID int64
+	path  string
 }
 
 func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *Service {
@@ -35,7 +43,7 @@ func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *S
 
 	// Initializing folder path cache with a TTL of 1 minute.
 	foldersCache := ttlcache.New(
-		ttlcache.WithTTL[string, string](1 * time.Minute),
+		ttlcache.WithTTL[folderCacheKey, string](1 * time.Minute),
 	)
 
 	return &Service{

--- a/pkg/grafana/service.go
+++ b/pkg/grafana/service.go
@@ -18,6 +18,13 @@ type Service struct {
 	// same "get org by name" Grafana API call. The short TTL keeps
 	// it fresh enough to pick up organizations created or renamed out-of-band.
 	organizationCache *ttlcache.Cache[string, *organization.Organization]
+
+	// foldersCache memoizes the leaf folder UID for a given folder path. Resolving a
+	// path otherwise issues a Grafana API call per segment to check/create each folder;
+	// caching the resolved UID avoids re-walking unchanged hierarchies.
+	// The short TTL bounds how long a folder deleted out-of-band stays
+	// "resolved" in the cache.
+	foldersCache *ttlcache.Cache[string, string]
 }
 
 func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *Service {
@@ -26,9 +33,15 @@ func NewService(grafanaClient grafanaClient.GrafanaClient, cfg config.Config) *S
 		ttlcache.WithTTL[string, *organization.Organization](1 * time.Minute),
 	)
 
+	// Initializing folder path cache with a TTL of 1 minute.
+	foldersCache := ttlcache.New(
+		ttlcache.WithTTL[string, string](1 * time.Minute),
+	)
+
 	return &Service{
 		grafanaClient:     grafanaClient,
 		cfg:               cfg,
 		organizationCache: organizationCache,
+		foldersCache:      foldersCache,
 	}
 }


### PR DESCRIPTION
## What

Moves orphaned Grafana folder cleanup off the dashboard reconcile path and into a dedicated, debounced background runnable.

Previously, every dashboard create/delete reconcile ran `cleanupOrphanedFolders` inline, which lists all folders and dashboard ConfigMaps for the organization — an expensive operation that ran on every reconcile and could amplify badly during bursts (e.g. a Grafana pod restart re-enqueues every dashboard ConfigMap at once).

## How

- New `folderCleaner` (`internal/controller/dashboard_folder_cleaner.go`) implements `manager.Runnable` and is owned by the controller manager's lifecycle.
- Reconcile paths now call `cleaner.Trigger(org)` instead of running cleanup inline — a non-blocking, safe-from-any-goroutine call that only schedules work.
- Cleanup is **debounced**: each `Trigger` resets a 10s timer, so cleanup runs once after a burst of reconciliations settles rather than per-reconcile.
- Failed cleanups retry with jittered exponential backoff (10s → 5min cap); the backoff resets after a new burst or a successful run.
- The cleaner stays idle until triggered and never runs on its own.

## Bonus: fixes a deletion edge case

On dashboard deletion, the inline cleanup ran *before* the ConfigMap was actually deleted (cleanup happened ahead of finalizer removal), so the deleted dashboard's folder was still counted as "required" and never cleaned up. Because cleanup is now debounced and runs after the reconcile completes, the ConfigMap is gone by the time required folder UIDs are recomputed, so the orphaned folder is correctly removed.

## Notes

- Removes the now-dead `cleanupOrphanedFolders` / `collectRequiredFolderUIDs` methods from the reconciler.

Towards: https://github.com/giantswarm/giantswarm/issues/35919
