### PR TITLE
feat: Move dashboard folder cleanup to its own controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Move orphaned dashboard folder cleanup out of the dashboard controller into a new `dashboard-cleanup` controller that reconciles per Grafana organization. Cleanup is debounced and runs once, one minute after the first dashboard event of a burst, instead of after every dashboard reconciliation.
+
 ## [0.71.0] - 2026-06-17
 
 ### Changed

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -557,6 +557,12 @@ func setupApplication() error {
 		if err != nil {
 			return fmt.Errorf("unable to create controller (Dashboard): %w", err)
 		}
+
+		// Setup the controller that asynchronously cleans up orphaned folders per organization.
+		err = controller.SetupDashboardCleanupReconciler(mgr, cfg, grafanaClientGen)
+		if err != nil {
+			return fmt.Errorf("unable to create controller (DashboardCleanup): %w", err)
+		}
 	}
 
 	// nolint:goconst

--- a/internal/controller/dashboard_cleanup_controller.go
+++ b/internal/controller/dashboard_cleanup_controller.go
@@ -1,0 +1,202 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/giantswarm/observability-operator/internal/labels"
+	"github.com/giantswarm/observability-operator/internal/mapper"
+	"github.com/giantswarm/observability-operator/pkg/config"
+	"github.com/giantswarm/observability-operator/pkg/domain/folder"
+	"github.com/giantswarm/observability-operator/pkg/grafana"
+	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
+)
+
+// dashboardCleanupDelay is how long the controller waits after the first
+// dashboard event before cleaning up orphaned folders for an organization.
+// Dashboard events arrive in bursts (one ConfigMap per dashboard), so we
+// debounce them: the delaying queue keeps the earliest scheduled time per
+// organization key, meaning cleanup runs once, this long after the first event
+// of a burst, by which point all dashboards have been reconciled.
+const dashboardCleanupDelay = time.Minute
+
+// DashboardCleanupReconciler removes orphaned Grafana folders for an organization.
+// It is keyed by organization name (carried in the reconcile request Name) rather
+// than by a single ConfigMap, so it runs once per organization after a burst of
+// dashboard events instead of once per dashboard.
+type DashboardCleanupReconciler struct {
+	client.Client
+	Scheme *runtime.Scheme
+
+	grafanaURL       *url.URL
+	dashboardMapper  *mapper.DashboardMapper
+	grafanaClientGen grafanaclient.GrafanaClientGenerator
+	cfg              config.Config
+	cleanupDelay     time.Duration
+}
+
+func SetupDashboardCleanupReconciler(mgr manager.Manager, cfg config.Config, grafanaClientGen grafanaclient.GrafanaClientGenerator) error {
+	r := &DashboardCleanupReconciler{
+		Client: mgr.GetClient(),
+		Scheme: mgr.GetScheme(),
+
+		grafanaURL:       cfg.Grafana.URL,
+		dashboardMapper:  mapper.New(),
+		grafanaClientGen: grafanaClientGen,
+		cfg:              cfg,
+		cleanupDelay:     dashboardCleanupDelay,
+	}
+
+	return r.SetupWithManager(mgr)
+}
+
+// Reconcile removes operator-managed folders that are no longer referenced by any
+// dashboard ConfigMap of the organization identified by req.Name.
+func (r *DashboardCleanupReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	orgName := req.Name
+
+	grafanaAPI, err := r.grafanaClientGen.GenerateGrafanaClient(ctx, r.Client, r.grafanaURL)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to generate Grafana client: %w", err)
+	}
+
+	grafanaService := grafana.NewService(grafanaAPI, r.cfg)
+
+	return ctrl.Result{}, r.cleanupOrphanedFolders(ctx, grafanaService, orgName)
+}
+
+// SetupWithManager sets up the controller with the Manager. It watches dashboard
+// ConfigMaps but enqueues per-organization cleanup requests with a delay so that
+// a burst of dashboard events triggers a single cleanup once all dashboards have
+// been reconciled.
+func (r *DashboardCleanupReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	labelSelectorPredicate, err := predicate.LabelSelectorPredicate(
+		metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				labels.DashboardSelectorLabelName: labels.DashboardSelectorLabelValue,
+			},
+		})
+	if err != nil {
+		return fmt.Errorf("failed to create label selector predicate: %w", err)
+	}
+
+	err = ctrl.NewControllerManagedBy(mgr).
+		Named("dashboard-cleanup").
+		Watches(
+			&v1.ConfigMap{},
+			r.enqueueOrganizationCleanup(),
+			builder.WithPredicates(labelSelectorPredicate),
+		).
+		Complete(r)
+	if err != nil {
+		return fmt.Errorf("failed to build controller: %w", err)
+	}
+
+	return nil
+}
+
+// enqueueOrganizationCleanup returns an event handler that maps a dashboard
+// ConfigMap to its organization and schedules a delayed cleanup request. The
+// delaying queue keeps the earliest scheduled time per organization key, so
+// repeated events within a burst do not push the cleanup further out.
+func (r *DashboardCleanupReconciler) enqueueOrganizationCleanup() handler.EventHandler {
+	enqueue := func(obj client.Object, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+		req, ok := r.organizationRequest(obj)
+		if !ok {
+			return
+		}
+		q.AddAfter(req, r.cleanupDelay)
+	}
+
+	return handler.Funcs{
+		CreateFunc: func(_ context.Context, e event.CreateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(e.Object, q)
+		},
+		UpdateFunc: func(_ context.Context, e event.UpdateEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(e.ObjectNew, q)
+		},
+		DeleteFunc: func(_ context.Context, e event.DeleteEvent, q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+			enqueue(e.Object, q)
+		},
+	}
+}
+
+// organizationRequest extracts the organization from a dashboard ConfigMap and
+// builds the reconcile request used to key per-organization cleanup. It returns
+// false when the object is not a ConfigMap or has no organization set.
+func (r *DashboardCleanupReconciler) organizationRequest(obj client.Object) (reconcile.Request, bool) {
+	cm, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		return reconcile.Request{}, false
+	}
+
+	for _, dash := range r.dashboardMapper.FromConfigMap(cm) {
+		if org := dash.Organization(); org != "" {
+			return reconcile.Request{NamespacedName: types.NamespacedName{Name: org}}, true
+		}
+	}
+
+	return reconcile.Request{}, false
+}
+
+// cleanupOrphanedFolders resolves the organization, computes which folder UIDs are still
+// needed by dashboard ConfigMaps, and delegates deletion of orphans to the Grafana service.
+func (r *DashboardCleanupReconciler) cleanupOrphanedFolders(ctx context.Context, grafanaService *grafana.Service, orgName string) error {
+	org, err := grafanaService.FindOrgByName(orgName)
+	if err != nil {
+		return fmt.Errorf("failed to find organization %q: %w", orgName, err)
+	}
+
+	requiredUIDs, err := r.collectRequiredFolderUIDs(ctx, orgName)
+	if err != nil {
+		return fmt.Errorf("failed to collect required folder UIDs: %w", err)
+	}
+
+	return grafanaService.CleanupOrphanedFoldersForOrg(ctx, org, requiredUIDs)
+}
+
+// collectRequiredFolderUIDs lists all dashboard ConfigMaps for the given organization and computes the set of folder UIDs they reference.
+func (r *DashboardCleanupReconciler) collectRequiredFolderUIDs(ctx context.Context, orgName string) (map[string]struct{}, error) {
+	var configMaps v1.ConfigMapList
+	err := r.List(ctx, &configMaps, client.MatchingLabels{
+		labels.DashboardSelectorLabelName: labels.DashboardSelectorLabelValue,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dashboard configmaps: %w", err)
+	}
+
+	requiredUIDs := make(map[string]struct{})
+	for i := range configMaps.Items {
+		dashboards := r.dashboardMapper.FromConfigMap(&configMaps.Items[i])
+		for _, dash := range dashboards {
+			if dash.Organization() != orgName {
+				continue
+			}
+			if dash.FolderPath() == "" {
+				continue
+			}
+			segments := folder.ParsePath(dash.FolderPath())
+			for _, seg := range segments {
+				requiredUIDs[seg.UID()] = struct{}{}
+			}
+		}
+	}
+
+	return requiredUIDs, nil
+}

--- a/internal/controller/dashboard_cleanup_controller.go
+++ b/internal/controller/dashboard_cleanup_controller.go
@@ -30,16 +30,14 @@ import (
 
 // dashboardCleanupDelay is how long the controller waits after the first
 // dashboard event before cleaning up orphaned folders for an organization.
-// Dashboard events arrive in bursts (one ConfigMap per dashboard), so we
-// debounce them: the delaying queue keeps the earliest scheduled time per
-// organization key, meaning cleanup runs once, this long after the first event
-// of a burst, by which point all dashboards have been reconciled.
+// If dashboard configmap events arrive in bursts, so we debounce them: the
+// delaying queue keeps the earliest scheduled time per organization key,
+// meaning cleanup runs once, this long after the first event of a burst.
 const dashboardCleanupDelay = time.Minute
 
 // DashboardCleanupReconciler removes orphaned Grafana folders for an organization.
 // It is keyed by organization name (carried in the reconcile request Name) rather
-// than by a single ConfigMap, so it runs once per organization after a burst of
-// dashboard events instead of once per dashboard.
+// than by a single ConfigMap, so it runs once per organization.
 type DashboardCleanupReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
@@ -83,8 +81,7 @@ func (r *DashboardCleanupReconciler) Reconcile(ctx context.Context, req ctrl.Req
 
 // SetupWithManager sets up the controller with the Manager. It watches dashboard
 // ConfigMaps but enqueues per-organization cleanup requests with a delay so that
-// a burst of dashboard events triggers a single cleanup once all dashboards have
-// been reconciled.
+// a burst of dashboard events triggers a single cleanup.
 func (r *DashboardCleanupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	labelSelectorPredicate, err := predicate.LabelSelectorPredicate(
 		metav1.LabelSelector{

--- a/internal/controller/dashboard_cleanup_controller.go
+++ b/internal/controller/dashboard_cleanup_controller.go
@@ -8,7 +8,6 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/workqueue"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -40,7 +39,6 @@ const dashboardCleanupDelay = time.Minute
 // than by a single ConfigMap, so it runs once per organization.
 type DashboardCleanupReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
 
 	grafanaURL       *url.URL
 	dashboardMapper  *mapper.DashboardMapper
@@ -52,7 +50,6 @@ type DashboardCleanupReconciler struct {
 func SetupDashboardCleanupReconciler(mgr manager.Manager, cfg config.Config, grafanaClientGen grafanaclient.GrafanaClientGenerator) error {
 	r := &DashboardCleanupReconciler{
 		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
 
 		grafanaURL:       cfg.Grafana.URL,
 		dashboardMapper:  mapper.New(),

--- a/internal/controller/dashboard_cleanup_controller_test.go
+++ b/internal/controller/dashboard_cleanup_controller_test.go
@@ -1,0 +1,151 @@
+package controller
+
+import (
+	"context"
+	"net/url"
+	"testing"
+
+	"github.com/grafana/grafana-openapi-client-go/client/folders"
+	"github.com/grafana/grafana-openapi-client-go/client/orgs"
+	"github.com/grafana/grafana-openapi-client-go/models"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/giantswarm/observability-operator/internal/labels"
+	"github.com/giantswarm/observability-operator/internal/mapper"
+	"github.com/giantswarm/observability-operator/pkg/domain/folder"
+	"github.com/giantswarm/observability-operator/pkg/grafana/client/mocks"
+)
+
+// TestDashboardCleanupOrganizationRequest verifies that dashboard ConfigMaps are
+// mapped to a reconcile request keyed by their organization, which is what makes
+// the controller debounce a burst of dashboard events into a single per-org cleanup.
+func TestDashboardCleanupOrganizationRequest(t *testing.T) {
+	r := &DashboardCleanupReconciler{dashboardMapper: mapper.New()}
+
+	dashboardCM := func(org string) *v1.ConfigMap {
+		cm := &v1.ConfigMap{
+			Data: map[string]string{"dashboard.json": `{"uid":"u","title":"t"}`},
+		}
+		if org != "" {
+			cm.Annotations = map[string]string{labels.GrafanaOrganizationKey: org}
+		}
+		return cm
+	}
+
+	t.Run("configmap with organization is keyed by org name", func(t *testing.T) {
+		req, ok := r.organizationRequest(dashboardCM("My Org"))
+		require.True(t, ok)
+		require.Equal(t, reconcile.Request{NamespacedName: types.NamespacedName{Name: "My Org"}}, req)
+	})
+
+	t.Run("configmap without organization is skipped", func(t *testing.T) {
+		_, ok := r.organizationRequest(dashboardCM(""))
+		require.False(t, ok)
+	})
+
+	t.Run("non-configmap object is skipped", func(t *testing.T) {
+		_, ok := r.organizationRequest(&v1.Secret{})
+		require.False(t, ok)
+	})
+}
+
+var _ = Describe("Dashboard Cleanup Controller", func() {
+	const (
+		orgName            = "Cleanup Test Org"
+		dashboardNamespace = "default"
+	)
+
+	var (
+		ctx               context.Context
+		reconciler        *DashboardCleanupReconciler
+		mockGrafanaGen    *mocks.MockGrafanaClientGenerator
+		mockGrafanaClient *mocks.MockGrafanaClient
+		keptConfigMap     *v1.ConfigMap
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		ns := &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: dashboardNamespace}}
+		_ = k8sClient.Create(ctx, ns)
+
+		// A dashboard ConfigMap whose folder must be kept (it is still referenced).
+		keptConfigMap = &v1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kept-dashboard",
+				Namespace: dashboardNamespace,
+				Labels: map[string]string{
+					labels.DashboardSelectorLabelName: labels.DashboardSelectorLabelValue,
+				},
+				Annotations: map[string]string{
+					labels.GrafanaOrganizationKey: orgName,
+					labels.GrafanaFolderKey:       "keep-team",
+				},
+			},
+			Data: map[string]string{"dashboard.json": `{"uid":"kept-uid","title":"Kept"}`},
+		}
+		Expect(k8sClient.Create(ctx, keptConfigMap)).To(Succeed())
+
+		mockGrafanaGen = &mocks.MockGrafanaClientGenerator{}
+		mockGrafanaClient = &mocks.MockGrafanaClient{}
+		mockGrafanaGen.On("GenerateGrafanaClient", mock.Anything, mock.Anything, mock.Anything).Return(mockGrafanaClient, nil)
+		mockGrafanaClient.On("WithOrgID", mock.AnythingOfType("int64")).Return(mockGrafanaClient)
+
+		grafanaURL, _ := url.Parse("http://localhost:3000")
+		reconciler = &DashboardCleanupReconciler{
+			Client:           k8sClient,
+			Scheme:           k8sClient.Scheme(),
+			grafanaURL:       grafanaURL,
+			dashboardMapper:  mapper.New(),
+			grafanaClientGen: mockGrafanaGen,
+		}
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, keptConfigMap)
+		mockGrafanaClient.AssertExpectations(GinkgoT())
+		mockGrafanaGen.AssertExpectations(GinkgoT())
+	})
+
+	It("deletes orphaned operator-managed folders while keeping referenced ones", func() {
+		keptUID := folder.GenerateUID("keep-team")
+		orphanUID := folder.GenerateUID("old-team")
+
+		mockOrgsClient := &mocks.MockOrgsClient{}
+		mockGrafanaClient.On("Orgs").Return(mockOrgsClient)
+		mockOrgsClient.On("GetOrgByName", orgName).Return(&orgs.GetOrgByNameOK{
+			Payload: &models.OrgDetailsDTO{ID: 1, Name: orgName},
+		}, nil)
+
+		mockFoldersClient := &mocks.MockFoldersClient{}
+		mockGrafanaClient.On("Folders").Return(mockFoldersClient)
+		mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
+			Payload: []*models.FolderSearchHit{
+				{UID: keptUID, Title: "keep-team"},
+				{UID: orphanUID, Title: "old-team"},
+			},
+		}, nil)
+		// Only the orphaned folder is inspected and deleted; the referenced one is skipped.
+		mockFoldersClient.On("GetFolderDescendantCounts", orphanUID).Return(&folders.GetFolderDescendantCountsOK{
+			Payload: map[string]int64{},
+		}, nil)
+		mockFoldersClient.On("DeleteFolder", mock.MatchedBy(func(params *folders.DeleteFolderParams) bool {
+			return params.FolderUID == orphanUID
+		})).Return(&folders.DeleteFolderOK{}, nil)
+
+		result, err := reconciler.Reconcile(ctx, reconcile.Request{
+			NamespacedName: types.NamespacedName{Name: orgName},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(reconcile.Result{}))
+
+		mockFoldersClient.AssertExpectations(GinkgoT())
+	})
+})

--- a/internal/controller/dashboard_cleanup_controller_test.go
+++ b/internal/controller/dashboard_cleanup_controller_test.go
@@ -101,7 +101,6 @@ var _ = Describe("Dashboard Cleanup Controller", func() {
 		grafanaURL, _ := url.Parse("http://localhost:3000")
 		reconciler = &DashboardCleanupReconciler{
 			Client:           k8sClient,
-			Scheme:           k8sClient.Scheme(),
 			grafanaURL:       grafanaURL,
 			dashboardMapper:  mapper.New(),
 			grafanaClientGen: mockGrafanaGen,

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -25,7 +25,6 @@ import (
 	"github.com/giantswarm/observability-operator/internal/predicates"
 	"github.com/giantswarm/observability-operator/pkg/config"
 	"github.com/giantswarm/observability-operator/pkg/domain/dashboard"
-	"github.com/giantswarm/observability-operator/pkg/domain/folder"
 	"github.com/giantswarm/observability-operator/pkg/grafana"
 	grafanaclient "github.com/giantswarm/observability-operator/pkg/grafana/client"
 )
@@ -169,25 +168,15 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 		return nil
 	}
 
-	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
+	// Orphaned folder cleanup is handled asynchronously, per organization, by the
+	// DashboardCleanupReconciler once a burst of dashboard events has settled.
+	return r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.ConfigureDashboard(ctx, dash); err != nil {
 			return fmt.Errorf("failed to configure dashboard uid=%s from configMap=%s/%s: %w", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
 		}
 		log.FromContext(ctx).Info("dashboard configured in Grafana")
 		return nil
 	})
-	if err != nil {
-		return err
-	}
-
-	// Cleanup orphaned folders after all dashboards are processed
-	if org != "" {
-		if err := r.cleanupOrphanedFolders(ctx, grafanaService, org); err != nil {
-			return fmt.Errorf("failed to cleanup orphaned folders: %w", err)
-		}
-	}
-
-	return nil
 }
 
 // reconcileDelete deletes the grafana dashboard.
@@ -197,7 +186,9 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 		return nil
 	}
 
-	org, err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
+	// Orphaned folder cleanup is handled asynchronously, per organization, by the
+	// DashboardCleanupReconciler once a burst of dashboard events has settled.
+	err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.DeleteDashboard(ctx, dash); err != nil {
 			return fmt.Errorf("failed to delete dashboard uid=%s from configMap=%s/%s: %w", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
 		}
@@ -206,13 +197,6 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 	})
 	if err != nil {
 		return err
-	}
-
-	// Cleanup orphaned folders after all dashboards are deleted
-	if org != "" {
-		if err := r.cleanupOrphanedFolders(ctx, grafanaService, org); err != nil {
-			return fmt.Errorf("failed to cleanup orphaned folders: %w", err)
-		}
 	}
 
 	// Finalizer handling needs to come last.
@@ -225,23 +209,17 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 
 // processDashboards applies op to every dashboard parsed from the ConfigMap.
 // Errors are collected per dashboard so that a single failure does not prevent
-// the remaining dashboards from being processed. It returns the organization
-// shared by the dashboards (empty if the ConfigMap holds none) along with the
-// joined errors.
+// the remaining dashboards from being processed, and returned joined together.
 func (r *DashboardReconciler) processDashboards(
 	ctx context.Context,
 	dashboardConfigMap *v1.ConfigMap,
 	op func(ctx context.Context, dash *dashboard.Dashboard) error,
-) (string, error) {
+) error {
 	logger := log.FromContext(ctx)
 	dashboards := r.dashboardMapper.FromConfigMap(dashboardConfigMap)
 
-	org := ""
 	var errs []error
 	for _, dash := range dashboards {
-		// org is the same for all dashboards in the same configmap.
-		org = dash.Organization()
-
 		// Create a unique logger for the current dashboard.
 		dl := logger.WithValues(
 			"uid", dash.UID(),
@@ -260,51 +238,5 @@ func (r *DashboardReconciler) processDashboards(
 		}
 	}
 
-	return org, errors.Join(errs...)
-}
-
-// cleanupOrphanedFolders resolves the organization, computes which folder UIDs are still
-// needed by dashboard ConfigMaps, and delegates deletion of orphans to the Grafana service.
-func (r *DashboardReconciler) cleanupOrphanedFolders(ctx context.Context, grafanaService *grafana.Service, orgName string) error {
-	org, err := grafanaService.FindOrgByName(orgName)
-	if err != nil {
-		return fmt.Errorf("failed to find organization %q: %w", orgName, err)
-	}
-
-	requiredUIDs, err := r.collectRequiredFolderUIDs(ctx, orgName)
-	if err != nil {
-		return fmt.Errorf("failed to collect required folder UIDs: %w", err)
-	}
-
-	return grafanaService.CleanupOrphanedFoldersForOrg(ctx, org, requiredUIDs)
-}
-
-// collectRequiredFolderUIDs lists all dashboard ConfigMaps for the given organization and computes the set of folder UIDs they reference.
-func (r *DashboardReconciler) collectRequiredFolderUIDs(ctx context.Context, orgName string) (map[string]struct{}, error) {
-	var configMaps v1.ConfigMapList
-	err := r.List(ctx, &configMaps, client.MatchingLabels{
-		labels.DashboardSelectorLabelName: labels.DashboardSelectorLabelValue,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to list dashboard configmaps: %w", err)
-	}
-
-	requiredUIDs := make(map[string]struct{})
-	for i := range configMaps.Items {
-		dashboards := r.dashboardMapper.FromConfigMap(&configMaps.Items[i])
-		for _, dash := range dashboards {
-			if dash.Organization() != orgName {
-				continue
-			}
-			if dash.FolderPath() == "" {
-				continue
-			}
-			segments := folder.ParsePath(dash.FolderPath())
-			for _, seg := range segments {
-				requiredUIDs[seg.UID()] = struct{}{}
-			}
-		}
-	}
-
-	return requiredUIDs, nil
+	return errors.Join(errs...)
 }

--- a/internal/controller/dashboard_controller_test.go
+++ b/internal/controller/dashboard_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
-	"github.com/grafana/grafana-openapi-client-go/client/folders"
 	"github.com/grafana/grafana-openapi-client-go/client/orgs"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	. "github.com/onsi/ginkgo/v2"
@@ -196,13 +195,6 @@ var _ = Describe("Dashboard Controller", func() {
 							UID: func() *string { s := "test-dashboard-uid"; return &s }(),
 						},
 					}, nil)
-
-				// Mock the Folders service for cleanup
-				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
-				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
-					Payload: []*models.FolderSearchHit{},
-				}, nil)
 			})
 
 			AfterEach(func() {
@@ -339,13 +331,6 @@ var _ = Describe("Dashboard Controller", func() {
 					}
 					return false
 				})).Return(dashboardResponse, nil)
-
-				// Mock the Folders service for cleanup
-				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
-				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
-					Payload: []*models.FolderSearchHit{},
-				}, nil)
 
 				By("Creating a dashboard ConfigMap")
 				Expect(k8sClient.Create(ctx, dashboardConfigMap)).To(Succeed())
@@ -565,13 +550,6 @@ var _ = Describe("Dashboard Controller", func() {
 				}
 				mockDashboardsClient.On("DeleteDashboardByUID", "test-dashboard-uid").Return(deleteResponse, nil)
 
-				// Mock the Folders service for cleanup
-				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
-				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
-					Payload: []*models.FolderSearchHit{},
-				}, nil)
-
 				By("Marking the dashboard ConfigMap for deletion")
 				createdConfigMap := &v1.ConfigMap{}
 				err := k8sClient.Get(ctx, namespacedName, createdConfigMap)
@@ -681,13 +659,6 @@ var _ = Describe("Dashboard Controller", func() {
 					Payload: &models.PostDashboardOKBody{},
 				}
 				mockDashboardsClient.On("PostDashboard", mock.Anything).Return(dashboardResponse, nil)
-
-				// Mock the Folders service for cleanup
-				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
-				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
-					Payload: []*models.FolderSearchHit{},
-				}, nil)
 
 				// Test ConfigMap with organization in labels instead of annotations
 				// Note: Using a valid Kubernetes label value (no spaces, alphanumeric + dashes/dots/underscores)
@@ -843,13 +814,6 @@ var _ = Describe("Dashboard Controller", func() {
 				mockDashboardsClient := &mocks.MockDashboardsClient{}
 				mockGrafanaClient.On("Dashboards").Return(mockDashboardsClient)
 
-				// Mock the Folders service for cleanup
-				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
-				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
-					Payload: []*models.FolderSearchHit{},
-				}, nil)
-
 				configMapWithID := &v1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "dashboard-with-id",
@@ -984,13 +948,6 @@ var _ = Describe("Dashboard Controller", func() {
 				// Mock the Dashboards service
 				mockDashboardsClient := &mocks.MockDashboardsClient{}
 				mockGrafanaClient.On("Dashboards").Return(mockDashboardsClient)
-
-				// Mock the Folders service for cleanup
-				mockFoldersClient := &mocks.MockFoldersClient{}
-				mockGrafanaClient.On("Folders").Return(mockFoldersClient)
-				mockFoldersClient.On("GetFolders", mock.Anything).Return(&folders.GetFoldersOK{
-					Payload: []*models.FolderSearchHit{},
-				}, nil)
 
 				// Mock the organization lookup to succeed
 				orgResponse := &orgs.GetOrgByNameOK{


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/35720

### Problem


Even with recent changes the dashboard controller remains quite slow and takes ~2 seconds for **each** dashboard reconciliation, which total up to 5 minutes to reconciles 162 dashboards.
This is mainly due to the dashboard folder cleanup routine:

Orphaned-folder cleanup run inline at the end of every dashboard reconcile. Dashboard ConfigMaps arrive in bursts (the operator gets one event per dashboard),
  and each event triggered a full cleanup pass — which lists all dashboard ConfigMaps cluster-wide, resolves the org, computes required folder UIDs, and queries Grafana for orphans. So a
  burst of N dashboards meant N redundant, expensive cleanup sweeps.

### Solution

Cleanup is extracted into a dedicated dashboard-cleanup controller that is:
  - Keyed by organization name (not by ConfigMap) — the reconcile request's Name is the org, so all dashboards of an org collapse to one cleanup unit.
  - Debounced — the event handler calls q.AddAfter(req, 1*time.Minute). The delaying queue keeps the earliest scheduled time per key, so a burst of events for one org results in a single
  cleanup run, ~1 minute after the first event of the burst — by which point all dashboards have settled.

Therefore leaving the dashboard controller free of this heavy cleanup routine.
I've tested this and it greatly improves the dashboard controller speed which now now processing ~10 dashboard reconciliation per seconds that's a **200% increase**.

### How the new controller works

When a dashboard changes the new controller receive the event extract the organization for the given dashboard and delay its processing by 1 minute. Meaning that all dashboards events are de-duplicated by their organization, and only 1 cleanup per organization will occur. The processing is happening at 1 minute after the first event was received, this give a 1 minute window to absorb burst of dashboard changes, if the burst last longer than 1 minute then another cleanup will occur at the next minute and so on.


### What changed

- The dashboard folder cleanup routing itself was untouched and only moved to the new controller file.
- A new `DashboardCleanup` is added and started under the condition of the dashboard enabled flag.
- The `enqueueOrganizationCleanup` is the core logic here which deduplicated dashboards by organization and then rely on the [workqueue `AddAfter`](https://pkg.go.dev/k8s.io/client-go/util/workqueue#TypedDelayingInterface) to limit to 1 event per minute.
   Behavioral changes to be aware of
- Cleanup is now eventually-consistent, not synchronous. It no longer happens within the dashboard reconcile — it lags by up to ~1 minute. For orphaned-folder cleanup (a non-urgent
  garbage-collection task) this is a fine trade-off.
- Cleanup errors no longer fail the dashboard reconcile. Previously a cleanup failure surfaced as a dashboard reconcile error; now it's isolated to the cleanup controller's own retry loop.
  Dashboard provisioning succeeds independently.

### Before

<img width="1568" height="2620" alt="dashboard-flow-before" src="https://github.com/user-attachments/assets/b979a2ff-39df-42b9-8f26-1b25837308fb" />

### After

<img width="1568" height="1838" alt="dashboard-flow" src="https://github.com/user-attachments/assets/3a8e3925-1cc8-4de6-a6ed-d1728e01e049" />
