### PR TITLE
chore(deps): update dependency architect to v9.4.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@9.4.2
+  architect: giantswarm/architect@9.4.3
 
 jobs:
   go-tests:


### PR DESCRIPTION
This fixes an ongoing issue with OSS Index/Sonatype API, https://github.com/giantswarm/architect-orb/releases/tag/v9.4.3