### PR TITLE
fix: Fix Helm chart invalid characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix dashboard folders cleanup to process folders deepest-first
+- Fix invalid `helm.sh/chart` label containing invalid character in some cases
 
 ## [0.71.0] - 2026-06-17
 

--- a/helm/observability-operator/templates/_helpers.tpl
+++ b/helm/observability-operator/templates/_helpers.tpl
@@ -10,7 +10,7 @@ Expand the name of the chart.
 Create chart name and version as used by the chart label.
 */}}
 {{- define "chart" -}}
-{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimAll "-._" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
E2E CI tests are failing due to long branch name and invalid characters used in K8S resource labels.


```
{"caller":"github.com/giantswarm/helmclient/v4/pkg/helmclient/helmclient.go:139","controller":"chart-operator-chart","event":"update","function":"ApplyUpdateChange","level":"debug","loop":"11","message":"warning: Upgrade \"observability-operator\" failed: failed to create resource: NetworkPolicy.networking.k8s.io \"observability-operator\" is invalid: metadata.labels: Invalid value: \"observability-operator-0.71.1-dev.fix-alloy-scaling.2026-06-22.\": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')","object":"giantswarm/observability-operator","resource":"release","time":"2026-06-22T10:19:41.352689+00:00","version":"1620"}
```

[source](https://app.circleci.com/pipelines/github/giantswarm/observability-operator/5506/workflows/1707b1a9-7504-4e07-873b-f12cbae0ef85/jobs/32041)