### PR TITLE
Add validate-alertmanager-route CI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,14 @@ jobs:
     - run:
         name: Validate Alertmanager routes
         command: make tests-alertmanager-routes
+  tests-alertmanager-integrations:
+    machine:
+      image: ubuntu-2404:current
+    steps:
+    - checkout
+    - run:
+        name: Run Alertmanager integration tests
+        command: make tests-alertmanager-integrations
   verify-generate:
     executor: architect/architect
     steps:
@@ -65,6 +73,14 @@ workflows:
     # This job verifies that alerts route to the expected receivers.
     - validate-alertmanager-routes:
         name: validate-alertmanager-routes
+        filters:
+          tags:
+            only: /^v.*/
+
+    # This job verifies end-to-end that alerts are delivered to the expected
+    # receivers. It is slow, so it is intentionally not required by any other job.
+    - tests-alertmanager-integrations:
+        name: tests-alertmanager-integrations
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,10 @@ workflows:
         context: architect
         name: go-build
         requires:
+        - go-tests
         - validate-alertmanager-config
+        - validate-alertmanager-routes
+        - verify-generate
         path: ./cmd
         binary: observability-operator
         filters:
@@ -133,9 +136,6 @@ workflows:
         split-china-push: true
         requires:
         - go-build
-        - go-tests
-        - validate-alertmanager-routes
-        - verify-generate
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     - run:
         name: Validate Alertmanager routes
         command: make tests-alertmanager-routes
-  validate-alertmanager-routes-integration:
+  tests-alertmanager-integrations:
     machine:
       image: ubuntu-2404:current
     resource_class: large
@@ -93,7 +93,7 @@ workflows:
 
     # This job verifies end-to-end that alerts are delivered to the expected
     # receivers. It is slow, so it is intentionally not required by any other job.
-    - validate-alertmanager-routes-integration:
+    - tests-alertmanager-integrations:
         name: tests-alertmanager-integrations
         filters:
           tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
     - run:
         name: Validate Alertmanager routes
         command: make tests-alertmanager-routes
-  tests-alertmanager-integrations:
+  validate-alertmanager-routes-integration:
     machine:
       image: ubuntu-2404:current
     resource_class: large
@@ -93,7 +93,7 @@ workflows:
 
     # This job verifies end-to-end that alerts are delivered to the expected
     # receivers. It is slow, so it is intentionally not required by any other job.
-    - tests-alertmanager-integrations:
+    - validate-alertmanager-routes-integration:
         name: tests-alertmanager-integrations
         filters:
           tags:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,8 +36,22 @@ jobs:
   tests-alertmanager-integrations:
     machine:
       image: ubuntu-2404:current
+    resource_class: large
     steps:
     - checkout
+    - run:
+        name: Install kubectl
+        command: |
+          curl -sSLo kubectl "https://dl.k8s.io/release/$(curl -sSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+          chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+    - run:
+        name: Install Helm
+        command: curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+    - run:
+        name: Install kind
+        command: |
+          curl -sSLo kind "https://kind.sigs.k8s.io/dl/v0.27.0/kind-linux-amd64"
+          chmod +x kind && sudo mv kind /usr/local/bin/
     - run:
         name: Run Alertmanager integration tests
         command: make tests-alertmanager-integrations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,13 @@ jobs:
     - run:
         name: Validate Alertmanager Config
         command: make validate-alertmanager-config
+  validate-alertmanager-routes:
+    executor: architect/architect
+    steps:
+    - checkout
+    - run:
+        name: Validate Alertmanager routes
+        command: make tests-alertmanager-routes
   verify-generate:
     executor: architect/architect
     steps:
@@ -55,6 +62,13 @@ workflows:
           tags:
             only: /^v.*/
 
+    # This job verifies that alerts route to the expected receivers.
+    - validate-alertmanager-routes:
+        name: validate-alertmanager-routes
+        filters:
+          tags:
+            only: /^v.*/
+
     # This job validates that generated files (CRDs, RBAC, deepcopy, etc.) are up to date.
     - verify-generate:
         name: verify-generate
@@ -75,6 +89,7 @@ workflows:
         requires:
         - go-tests
         - validate-alertmanager-config
+        - validate-alertmanager-routes
         - verify-generate
         path: ./cmd
         binary: observability-operator

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,10 +103,7 @@ workflows:
         context: architect
         name: go-build
         requires:
-        - go-tests
         - validate-alertmanager-config
-        - validate-alertmanager-routes
-        - verify-generate
         path: ./cmd
         binary: observability-operator
         filters:
@@ -122,6 +119,9 @@ workflows:
         split-china-push: true
         requires:
         - go-build
+        - go-tests
+        - validate-alertmanager-routes
+        - verify-generate
         filters:
           tags:
             only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
 workflows:
   build:
     jobs:
+
     # This job is used to build the Helm chart and make sure it is valid.
     - template-chart:
         name: template-chart
@@ -67,6 +68,7 @@ workflows:
           tags:
             only: /^v.*/
 
+    # Build the observability-operator binary.
     - architect/go-build:
         context: architect
         name: go-build
@@ -79,6 +81,7 @@ workflows:
           tags:
             only: /^v.*/
 
+    # Push the observability-operator container image.
     - architect/push-to-registries:
         context: architect
         name: push-to-registries
@@ -109,6 +112,7 @@ workflows:
           branches:
             ignore: /.*/
 
+    # Push the observability-operator Helm chart.
     - architect/push-to-app-catalog:
         context: architect
         executor: app-build-suite
@@ -127,6 +131,7 @@ workflows:
             - main
             - master
 
+    # Run end to end tests.
     - architect/run-tests-with-ats:
         name: run-chart-tests-with-ats
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ workflows:
         requires:
         - go-tests
         - validate-alertmanager-config
+        - verify-generate
         path: ./cmd
         binary: observability-operator
         filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add alertmanager routes validation to CI checks
+
 ## [0.72.0] - 2026-06-22
 
 ### Changed

--- a/Makefile.custom.mk
+++ b/Makefile.custom.mk
@@ -35,8 +35,8 @@ endif
 KIND_CLUSTER_NAME = alertmanager-integration
 INTEGRATION_TEST_FLAGS = -count=1 -v -p 1 -test.timeout 30m -tags=integration -args \
 												 -alertmanager-config-dir $(ALERTMANAGER_TEST_CONFIG_DIR)
-MIMIR_CHART = oci://giantswarmpublic.azurecr.io/control-plane-catalog/mimir
-MIMIR_CHART_VERSION = 0.21.0
+MIMIR_CHART = oci://gsoci.azurecr.io/charts/giantswarm/mimir
+MIMIR_CHART_VERSION = 0.28.0
 
 ###############################################################################
 # Testing & Coverage

--- a/renovate.json5
+++ b/renovate.json5
@@ -16,6 +16,16 @@
       depNameTemplate: 'grafana/mimir',
       versioningTemplate: 'regex:^mimir-(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$',
     },
+    {
+      customType: 'regex',
+      managerFilePatterns: [
+        '/^Makefile\\.custom\\.mk$/',
+      ],
+      matchStrings: [
+        'MIMIR_CHART\\s*=\\s*oci://(?<depName>\\S+)\\s*\\nMIMIR_CHART_VERSION\\s*=\\s*(?<currentValue>\\S+)',
+      ],
+      datasourceTemplate: 'docker',
+    },
   ],
   packageRules: [
     {


### PR DESCRIPTION
### Problem

There are actually some (unit + end to end) tests to validate the Alertmanager routing logic, but those are never run from CI.
Those test should be run automatically to try and catch any potential problem introduced in the Alertmanager config and logic.
The setup for the end to end Alertmanater routing tests actually got broken due to the Mimir OCI repository and version change, I've fixed this here.

### Solution

Add 2 new jobs in the CI pipeline: 

- `validate-alertmanager-routes`: light unit tests which runs in about 1 minute, and make it a requirement for the rest of the pipeline
- `validate-alertmanager-routes-integration`: full integration tests running against a real Alertmanager, which runs in about 10 minute (which is slightly under the full build pipeline time, currently around 13 minutes), and not making it a requirement

I also made the `verify-generate` job required to `go-build` which would make the job fails in case some of the generated files are incorrect.

### Before

<img width="1836" height="374" alt="image" src="https://github.com/user-attachments/assets/58d42cd3-d21e-4d6f-a0bd-a9f5feeaeeaf" />


### After

<img width="1826" height="466" alt="image" src="https://github.com/user-attachments/assets/2f7abf61-b6a4-445b-b252-802785b9e861" />

