### PR TITLE
fix: Fix dashboard not found error on delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixes
+
+- Fix dashboard not found errors on delete
+
 ## [0.72.0] - 2026-06-22
 
 ### Changed

--- a/pkg/grafana/dashboard.go
+++ b/pkg/grafana/dashboard.go
@@ -59,18 +59,13 @@ func (s *Service) DeleteDashboard(ctx context.Context, dashboard *dashboard.Dash
 	}
 
 	err = s.withinOrganization(ctx, org, func(ctx context.Context, client grafanaclient.GrafanaClient) error {
-		_, err := client.Dashboards().GetDashboardByUID(dashboard.UID())
+		_, err = client.Dashboards().DeleteDashboardByUID(dashboard.UID())
 		if err != nil {
 			// Return with no error in case the dashboard is already gone in Grafana.
-			var notFound *dashboards.GetDashboardByUIDNotFound
+			var notFound *dashboards.DeleteDashboardByUIDNotFound
 			if errors.As(err, &notFound) {
 				return nil
 			}
-			return fmt.Errorf("failed to get dashboard: %w", err)
-		}
-
-		_, err = client.Dashboards().DeleteDashboardByUID(dashboard.UID())
-		if err != nil {
 			return fmt.Errorf("failed to delete dashboard: %w", err)
 		}
 

--- a/pkg/grafana/dashboard.go
+++ b/pkg/grafana/dashboard.go
@@ -2,8 +2,10 @@ package grafana
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/grafana/grafana-openapi-client-go/client/dashboards"
 	"github.com/grafana/grafana-openapi-client-go/models"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -59,6 +61,11 @@ func (s *Service) DeleteDashboard(ctx context.Context, dashboard *dashboard.Dash
 	err = s.withinOrganization(ctx, org, func(ctx context.Context, client grafanaclient.GrafanaClient) error {
 		_, err := client.Dashboards().GetDashboardByUID(dashboard.UID())
 		if err != nil {
+			// Return with no error in case the dashboard is already gone in Grafana.
+			var notFound *dashboards.GetDashboardByUIDNotFound
+			if errors.As(err, &notFound) {
+				return nil
+			}
 			return fmt.Errorf("failed to get dashboard: %w", err)
 		}
 

--- a/pkg/grafana/dashboard.go
+++ b/pkg/grafana/dashboard.go
@@ -52,6 +52,8 @@ func (s *Service) ConfigureDashboard(ctx context.Context, dashboard *dashboard.D
 }
 
 func (s *Service) DeleteDashboard(ctx context.Context, dashboard *dashboard.Dashboard) error {
+	logger := log.FromContext(ctx)
+
 	org, err := s.FindOrgByName(dashboard.Organization())
 	if err != nil {
 		metrics.GrafanaAPIErrors.WithLabelValues(metrics.OpDeleteDashboard).Inc()
@@ -64,6 +66,7 @@ func (s *Service) DeleteDashboard(ctx context.Context, dashboard *dashboard.Dash
 			// Return with no error in case the dashboard is already gone in Grafana.
 			var notFound *dashboards.DeleteDashboardByUIDNotFound
 			if errors.As(err, &notFound) {
+				logger.Info("skipping deletion, dashboard not found")
 				return nil
 			}
 			return fmt.Errorf("failed to delete dashboard: %w", err)


### PR DESCRIPTION
### Problem

When a dashboard no longer exists in Grafana it fails to be deleted with a "Dashboard not found" error and the corresponding configmap is stuck in deletion due to the finalizer not being removed.

Example output

```
2026-06-22 16:12:27.000 [ERR] Reconciler error › controller=dashboard controllerGroup="" controllerKind=ConfigMap ConfigMap.name=grafana-2ad000f5-kube-proxy-dashboard ConfigMap.namespace=monitoring namespace=monitoring name=grafana-2ad000f5-kube-proxy-dashboard reconcileID=8fc714b3-d3a0-419e-8422-a2f236ab3886 error='failed to delete dashboard uid=qMN01qkWs from configMap=monitoring/grafana-2ad000f5-kube-proxy-dashboard: failed to get dashboard: [GET /dashboards/uid/{uid}][404] getDashboardByUidNotFound {"message":"Dashboard not found"}'
                        [ ~ ]   > stacktrace=|=>
                        [ ~ ]      	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
                        [ ~ ]      		sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494
                        [ ~ ]      	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
                        [ ~ ]      		sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437
                        [ ~ ]      	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
                        [ ~ ]      		sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312
```

### Solution

This PR fixes this issue by adding a special case to handle the dashboard not found error.