### PR TITLE
fix: Change the `skipping deletion, orphaned folder is not empty` error to a simple info log message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change the "skipping deletion, orphaned folder is not empty" error to a simple info log message
+
 ## [0.72.0] - 2026-06-22
 
 ### Changed

--- a/pkg/grafana/folder.go
+++ b/pkg/grafana/folder.go
@@ -132,7 +132,7 @@ func (s *Service) CleanupOrphanedFoldersForOrg(ctx context.Context, org *organiz
 			}
 
 			if !isEmpty {
-				errs = append(errs, fmt.Errorf("skipping deletion, orphaned folder is not empty uid=%s title=%s", f.UID, f.Title))
+				logger.Info("skipping deletion, orphaned folder is not empty", "uid", f.UID, "title", f.Title)
 				continue
 			}
 

--- a/pkg/grafana/folder_test.go
+++ b/pkg/grafana/folder_test.go
@@ -382,7 +382,7 @@ func TestCleanupOrphanedFoldersForOrg_SkipsNonOperatorManagedFolders(t *testing.
 	mockFolders.AssertNotCalled(t, "DeleteFolder", mock.Anything)
 }
 
-func TestCleanupOrphanedFoldersForOrg_NonEmptyFolderReturnsError(t *testing.T) {
+func TestCleanupOrphanedFoldersForOrg_NonEmptyFolderIsSkipped(t *testing.T) {
 	mockClient := &mocks.MockGrafanaClient{}
 	mockFolders := &mocks.MockFoldersClient{}
 	setupOrgContextMocks(mockClient)
@@ -401,12 +401,10 @@ func TestCleanupOrphanedFoldersForOrg_NonEmptyFolderReturnsError(t *testing.T) {
 		Payload: map[string]int64{"dashboards": 3},
 	}, nil)
 
+	// Non-empty orphaned folders are skipped (logged), not treated as an error
 	err := svc.CleanupOrphanedFoldersForOrg(context.Background(), testOrg(), map[string]struct{}{})
-	if err == nil {
-		t.Fatal("expected error for non-empty orphaned folder, got nil")
-	}
-	if !strings.Contains(err.Error(), "not empty") {
-		t.Errorf("expected error to mention 'not empty', got: %v", err)
+	if err != nil {
+		t.Fatalf("unexpected error for non-empty orphaned folder: %v", err)
 	}
 
 	// DeleteFolder should NOT have been called
@@ -488,10 +486,11 @@ func TestCleanupOrphanedFoldersForOrg_AccumulatesMultipleErrors(t *testing.T) {
 	// First folder: descendant counts fail
 	mockFolders.On("GetFolderDescendantCounts", uid1).Return(nil, errors.New("error-1"))
 
-	// Second folder: non-empty
+	// Second folder: empty, but delete fails
 	mockFolders.On("GetFolderDescendantCounts", uid2).Return(&folders.GetFolderDescendantCountsOK{
-		Payload: map[string]int64{"dashboards": 1},
+		Payload: map[string]int64{},
 	}, nil)
+	mockFolders.On("DeleteFolder", mock.Anything).Return(nil, errors.New("error-2"))
 
 	err := svc.CleanupOrphanedFoldersForOrg(context.Background(), testOrg(), map[string]struct{}{})
 	if err == nil {
@@ -502,8 +501,8 @@ func TestCleanupOrphanedFoldersForOrg_AccumulatesMultipleErrors(t *testing.T) {
 	if !strings.Contains(errStr, "failed to get descendant counts") {
 		t.Errorf("expected descendant counts error, got: %v", err)
 	}
-	if !strings.Contains(errStr, "not empty") {
-		t.Errorf("expected non-empty error, got: %v", err)
+	if !strings.Contains(errStr, "failed to delete orphaned folder") {
+		t.Errorf("expected delete error, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
### Problem

Current when a folder is not empty its deletion is skipped, but this yield an error from the operator which can raise a alert later.

Example message

```
2026-06-22 16:24:06.000 [ERR] Reconciler error › controller=dashboard-cleanup namespace="" name="Giant Swarm" reconcileID=4ee8894b-41a9-4cf0-ae06-29ce247a2e4d error="skipping deletion, orphaned folder is not empty uid=gs-e4a5f92fd340 title=Kafka"
                        [ ~ ]   > stacktrace=|=>
                        [ ~ ]      	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
                        [ ~ ]      		sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494
                        [ ~ ]      	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
                        [ ~ ]      		sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437
                        [ ~ ]      	sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
                        [ ~ ]      		sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312
```

### Solution

Change this message to rather be logger instead of throwing an error.