### PR TITLE
feat: annotate dashboard controller errors with organization and folder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.72.1] - 2026-06-23
 
 ### Changed
+
 - Annotate dashboard related errors with organization and folder
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Annotate dashboard and dashboard-cleanup controller error messages with debugging context (organization and folder) in addition to the dashboard UID and source ConfigMap.
+
 ## [0.72.0] - 2026-06-22
 
 ### Changed

--- a/internal/controller/dashboard_cleanup_controller.go
+++ b/internal/controller/dashboard_cleanup_controller.go
@@ -159,10 +159,14 @@ func (r *DashboardCleanupReconciler) cleanupOrphanedFolders(ctx context.Context,
 
 	requiredUIDs, err := r.collectRequiredFolderUIDs(ctx, orgName)
 	if err != nil {
-		return fmt.Errorf("failed to collect required folder UIDs: %w", err)
+		return fmt.Errorf("failed to collect required folder UIDs for org %q: %w", orgName, err)
 	}
 
-	return grafanaService.CleanupOrphanedFoldersForOrg(ctx, org, requiredUIDs)
+	if err := grafanaService.CleanupOrphanedFoldersForOrg(ctx, org, requiredUIDs); err != nil {
+		return fmt.Errorf("failed to cleanup orphaned folders for org %q: %w", orgName, err)
+	}
+
+	return nil
 }
 
 // collectRequiredFolderUIDs lists all dashboard ConfigMaps for the given organization and computes the set of folder UIDs they reference.
@@ -173,7 +177,7 @@ func (r *DashboardCleanupReconciler) collectRequiredFolderUIDs(ctx context.Conte
 		labels.DashboardSelectorLabelName: labels.DashboardSelectorLabelValue,
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to list dashboard configmaps: %w", err)
+		return nil, fmt.Errorf("failed to list dashboard configmaps for org %q: %w", orgName, err)
 	}
 
 	// Filter dashboards by organization and collect folder UIDs

--- a/internal/controller/dashboard_controller.go
+++ b/internal/controller/dashboard_controller.go
@@ -172,7 +172,7 @@ func (r *DashboardReconciler) reconcileCreate(ctx context.Context, grafanaServic
 	// DashboardCleanupReconciler once a burst of dashboard events has settled.
 	return r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.ConfigureDashboard(ctx, dash); err != nil {
-			return fmt.Errorf("failed to configure dashboard uid=%s from configMap=%s/%s: %w", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
+			return fmt.Errorf("failed to configure dashboard uid=%s org=%s folder=%s from configMap=%s/%s: %w", dash.UID(), dash.Organization(), dash.FolderPath(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
 		}
 		log.FromContext(ctx).Info("dashboard configured in Grafana")
 		return nil
@@ -190,7 +190,7 @@ func (r *DashboardReconciler) reconcileDelete(ctx context.Context, grafanaServic
 	// DashboardCleanupReconciler once a burst of dashboard events has settled.
 	err := r.processDashboards(ctx, dashboardConfigMap, func(ctx context.Context, dash *dashboard.Dashboard) error {
 		if err := grafanaService.DeleteDashboard(ctx, dash); err != nil {
-			return fmt.Errorf("failed to delete dashboard uid=%s from configMap=%s/%s: %w", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
+			return fmt.Errorf("failed to delete dashboard uid=%s org=%s folder=%s from configMap=%s/%s: %w", dash.UID(), dash.Organization(), dash.FolderPath(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), err)
 		}
 		log.FromContext(ctx).Info("dashboard deleted from Grafana")
 		return nil
@@ -229,7 +229,7 @@ func (r *DashboardReconciler) processDashboards(
 
 		// Defensive validation: ensure dashboards are valid even if webhook was bypassed.
 		if validationErrors := dash.Validate(); len(validationErrors) > 0 {
-			errs = append(errs, fmt.Errorf("dashboard validation failed - webhook may have been bypassed - for uid=%s from configMap=%s/%s: %v", dash.UID(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), validationErrors))
+			errs = append(errs, fmt.Errorf("dashboard validation failed - webhook may have been bypassed - for uid=%s org=%s folder=%s from configMap=%s/%s: %v", dash.UID(), dash.Organization(), dash.FolderPath(), dashboardConfigMap.GetNamespace(), dashboardConfigMap.GetName(), validationErrors))
 			continue
 		}
 


### PR DESCRIPTION
## What

Dashboard and dashboard-cleanup controller error messages now carry the organization and folder alongside the dashboard UID and source ConfigMap.

- **Dashboard controller** (`dashboard_controller.go`): added `org=` and `folder=` to the configure, delete, and validation error messages. These wrap everything the controller delegates to, so descendant errors inherit org/folder/uid context as they bubble up.
- **Dashboard-cleanup controller** (`dashboard_cleanup_controller.go`): `CleanupOrphanedFoldersForOrg`'s error was previously returned unwrapped, so its internal folder errors reached the logs with no organization. Now wrapped with `org %q` at the controller boundary, along with the two sibling errors that had `orgName` in scope but omitted it.

Callees in `pkg/grafana/dashboard.go` and `folder.go` were left unchanged — they are always reached through a wrapping controller, so adding org there would print it twice.

## Changelog

Entry added under `[Unreleased]`.