### PR TITLE
fix: remove redundant L7 rule from `alloy-events` `CiliumNetworkPolicy`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add alertmanager routes validation to CI checks
 - Add team bumblebee Slack alert routing (`#alert-bumblebee`)
 
+### Removed
+
+- Remove redundant L7 rule from `alloy-events` `CiliumNetworkPolicy`. The removed rule allowed DNS queries to any DNS domain so removing it has no effect.
+
 ## [0.72.1] - 2026-06-23
 
 ### Changed

--- a/pkg/agent/collectors/events/templates/events-logger-config.yaml.template
+++ b/pkg/agent/collectors/events/templates/events-logger-config.yaml.template
@@ -37,9 +37,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     {{- if or .TracingEnabled .MonitoringEnabled .LoggingEnabled }}
     ingress:
     - toPorts:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.all-signals.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.all-signals.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.loki-events.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.loki-events.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.monitoring-enabled.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.monitoring-enabled.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.tracing-enabled.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.MC.tracing-enabled.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.all-signals.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.all-signals.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.loki-events-exclude-namespaces.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.loki-events-exclude-namespaces.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.loki-events-include-namespaces.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.loki-events-include-namespaces.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.loki-events.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.loki-events.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.monitoring-enabled.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.monitoring-enabled.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:

--- a/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.tracing-enabled.yaml
+++ b/pkg/agent/collectors/events/testdata/events-logger-config.alloy.WC.tracing-enabled.yaml
@@ -22,9 +22,6 @@ networkPolicy:
           protocol: ANY
         - port: "1053"
           protocol: ANY
-        rules:
-          dns:
-            - matchPattern: '*'
     ingress:
     - toPorts:
       - ports:


### PR DESCRIPTION
### What this PR does / why we need it

Cilium on AKS doesn't have L7 proxy feature enabled, so such policies do not work.

The removed rule allowed DNS queries to any DNS domain so removing it has no effect.

Same was [applied in `alloy-app`](https://github.com/giantswarm/alloy-app/pull/268) but this config overrides the one in the chart.


### Checklist

- [x] `CHANGELOG.md` updated under `[Unreleased]`
- [x] Docs under `docs/` and `README.md` updated if the change affects operator behaviour, feature flags, CRD fields, exposed metrics, or configuration
