### PR TITLE
test: Add a regression test for msteamsv2_configs Alertmanager receiv…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a regression test for msteamsv2_configs Alertmanager receiver configuration
+- Add a regression test for msteamsv2_configs and msteams_config Alertmanager receivers configuration
 
 ## [0.72.3] - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a regression test for msteamsv2_configs Alertmanager receiver configuration
+
 ## [0.72.3] - 2026-08-03
 
 ### Added

--- a/pkg/alerting/alertmanager/alertmanager_test.go
+++ b/pkg/alerting/alertmanager/alertmanager_test.go
@@ -59,6 +59,14 @@ func TestValidate(t *testing.T) {
 			errContains: "invalid template",
 		},
 		{
+			// Ensure the msteams_configs Alertmanager receiver is a valid configuration.
+			name: "msteams receiver",
+			data: map[string][]byte{
+				AlertmanagerConfigKey: []byte("route:\n  receiver: msteams_receiver\nreceivers:\n  - name: msteams_receiver\n    msteams_configs:\n      - webhook_url: https://localhost.local\n"),
+			},
+			wantErr: false,
+		},
+		{
 			// Ensure the msteamsv2_configs Alertmanager receiver is a valid configuration.
 			name: "msteamsv2 receiver",
 			data: map[string][]byte{

--- a/pkg/alerting/alertmanager/alertmanager_test.go
+++ b/pkg/alerting/alertmanager/alertmanager_test.go
@@ -58,6 +58,14 @@ func TestValidate(t *testing.T) {
 			wantErr:     true,
 			errContains: "invalid template",
 		},
+		{
+			// Ensure the msteamsv2_configs Alertmanager receiver is a valid configuration.
+			name: "msteamsv2 receiver",
+			data: map[string][]byte{
+				AlertmanagerConfigKey: []byte("route:\n  receiver: msteamsv2_receiver\nreceivers:\n  - name: msteamsv2_receiver\n    msteamsv2_configs:\n      - webhook_url: https://localhost.local\n"),
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/37331

This PR add a regression test to ensure the `msteamsv2` Alertmanager config receiver works and can be decoded by the operator.